### PR TITLE
Add Code2Skill v1.1.3

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -19,7 +19,7 @@
 
 DeepSeek Harness is DeepSeek's open-source agent harness — a runnable coding agent (Web and headless), built on a framework where everything is a plugin: models, tools, sandboxes, session storage, UI, even the agent loop itself. Plugins can extend the official coding agent, swap out its core parts, or assemble something entirely different.
 
-**270** plugins · [PRs welcome](#contributing)
+**271** plugins · [PRs welcome](#contributing)
 
 ## Contents
 
@@ -219,6 +219,7 @@ DeepSeek Harness is DeepSeek's open-source agent harness — a runnable coding a
 ### Skills
 
 - [creght-dev/skills](https://github.com/creght-dev/skills) - Skills for building websites on the Creght platform: CLI pull/push sync, page and component conventions, CMS, forms, auth, SEO, publishing and version rollback.
+- [leechen298/Code2Skill](https://github.com/leechen298/Code2Skill) - Generates Function, MCP, Agent Skill, and offline test packages from existing code as an installable DSH bundle.
 
 ### Workflow & Automation
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行的 Coding Agent（提供 Web 与 headless 两种形式），底层又是一套「一切皆插件」的框架：模型、工具、沙箱、会话存储、UI、乃至 Agent Loop 本身都是插件。插件既可以扩展官方 Coding Agent，也可以替换其核心部件，甚至组装出完全不同的东西。
 
-**270** 个插件 · 欢迎 [PR](#贡献)
+**271** 个插件 · 欢迎 [PR](#贡献)
 
 ## 目录
 
@@ -219,6 +219,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 ### 🧩 技能包
 
 - [creght-dev/skills](https://github.com/creght-dev/skills) — Creght 平台建站技能包：CLI 拉取/推送同步、页面与组件规范、CMS、表单、Auth、SEO、发布与版本回滚。
+- [leechen298/Code2Skill](https://github.com/leechen298/Code2Skill) — 从现有代码生成 Function、MCP、Agent Skill 和离线测试包，并作为可安装的 DSH Bundle 分发。
 
 ### 🔁 工作流与自动化
 


### PR DESCRIPTION
## What changed

Add `leechen298/Code2Skill` to the Skills category in both the Chinese and English READMEs, and update the generated plugin counts.

## Why

Code2Skill v1.1.3 packages Function, MCP, Agent Skill, and offline-test generation capabilities as an installable DeepSeek Harness bundle. The repository is public, MIT licensed, tagged `dsh-plugin`, and declares `dsh.bundle.patch` in its root `package.json`.

Release: https://github.com/leechen298/Code2Skill/releases/tag/v1.1.3

## Validation

- [x] `node scripts/probe-npm.mjs`
- [x] `node scripts/build-site.mjs` (271 entries parsed consistently across both locales)
- [x] `git diff --check`
- [x] Added one matching entry to both `README.md` and `README.en.md`
- [x] Description is factual and contains no superlatives
- [x] Source repository has the `dsh-plugin` topic and a root `dsh.bundle` manifest