### PR TITLE
Add dsh-reverse-skill (85-skill reverse-engineering pack) to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [免责声明](#免责声明)
 
 ## 插件
+- [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) — 完整 reverse-skill（85 个 SKILL.md）的 DeepSeek Harness 插件：逆向工程、授权渗透测试与安全研究的技能路由包。
+- [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) - Complete reverse-skill pack (85 SKILL.md) as a DeepSeek Harness Cordis plugin: reverse engineering, authorized pentesting and security-research skill router.
 
 ### 🎨 UI 增强
 - [zealot00/dsh-pet](https://github.com/zealot00/dsh-pet) — DSH Web UI 桌面宠物：精灵图动画、agent 状态联动、拖拽、闹钟（每天/一次）与番茄钟，皮肤下拉选择 + 预览。
@@ -374,4 +376,3 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 ## 免责声明
 
 本项目是社区维护的索引。插件由各自作者开发与维护，收录不构成背书，亦不对任何插件的安全性、质量或维护状态作出保证。安装插件即在你的机器上运行第三方代码——请自行审阅源码、风险自担。本项目与 DeepSeek 无隶属关系。
-


### PR DESCRIPTION
Adds [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) — a DeepSeek Harness Cordis plugin bundling 85 SKILL.md reverse-engineering / authorized-pentest / security-research skills.

Installable via `dsh plugin add github:dhicoc/dsh-reverse-skill`.