### PR TITLE
相关：收录 dsh-ops（DeepSeek Harness 独立运维工具箱）

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -355,6 +355,7 @@ This project actively supports and acknowledges the [LINUX DO](https://linux.do)
 
 - [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) - Official runtime and core documentation.
 - [DeepSeek](https://deepseek.com) - Official site.
+- [dsh-ops](https://github.com/MiraculousGarfield/dsh-ops) - Standalone ops toolkit for dsh: one-click health check, config snapshot/restore, service watchdog and an incident runbook (plain PowerShell, no AI needed).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 
 - [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) - 官方运行时与核心文档。
 - [DeepSeek](https://deepseek.com) - 官方入口。
+- [dsh-ops](https://github.com/MiraculousGarfield/dsh-ops) - dsh 运维工具箱：一键健康检查、配置快照/还原、服务看门狗与事故运维手册（纯本地脚本，无需 AI）。
 
 ## 贡献
 


### PR DESCRIPTION
在“相关”区收录 [dsh-ops](https://github.com/MiraculousGarfield/dsh-ops)（不是插件，故放在相关区而非插件列表）：

- 面向 DeepSeek Harness 的独立运维工具集（Windows/PowerShell）
- 一键健康检查、配置快照/还原、服务看门狗、事故运维手册（runbook）
- 纯本地脚本，无需 AI，0 token——专为“dsh 自身无法自诊断”的宿主级故障场景设计（核心包重复导致所有会话 1ms 崩溃的那类问题）
- 两个 README 已同步

English summary: adding dsh-ops (standalone ops toolkit for DeepSeek Harness) to the Related section; both READMEs kept in sync.