### PR TITLE
Add zhtx2024/dsh-skin-switcher to Themes & Appearance

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -112,6 +112,7 @@ This project actively supports and acknowledges the [LINUX DO](https://linux.do)
 - [wsxwj123/dsh-plugins#theme-gallery](https://github.com/wsxwj123/dsh-plugins/tree/main/packages/theme-gallery) - Fifteen curated theme families with complete light and dark palettes that follow the native Light, Dark, and Follow system modes.
 - [dsh-skins](https://github.com/dsh-external/dsh-skins) - Web UI skins.
 - [BeiZi6/dsh-theme-plugin](https://github.com/BeiZi6/dsh-theme-plugin) - Theme studio for the DSH Web GUI: five built-in presets plus fully customizable light/dark palettes (accent, background, foreground, UI and code fonts, translucent sidebar, contrast), hot-swapped instantly and persisted in localStorage.
+- [zhtx2024/dsh-skin-switcher](https://github.com/zhtx2024/dsh-skin-switcher) - Adds a Skins page to Settings that auto-discovers installed skins for one-click switching, with one-click restore to the official default look.
 
 ### Sessions & Messages
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [wsxwj123/dsh-plugins#theme-gallery](https://github.com/wsxwj123/dsh-plugins/tree/main/packages/theme-gallery) — 15 个精选主题家族，浅深配色完整，跟随 DSH 原生浅色/深色/跟随系统模式。
 - [dsh-skins](https://github.com/dsh-external/dsh-skins) — Web UI 皮肤。
 - [BeiZi6/dsh-theme-plugin](https://github.com/BeiZi6/dsh-theme-plugin) — DSH Web GUI 主题工作室：5 套内置预设 + 完全可自定义的浅/深配色（强调色、背景、前景、UI 与代码字体、半透明侧栏、对比度），即时热切换并持久化到 localStorage。
+- [zhtx2024/dsh-skin-switcher](https://github.com/zhtx2024/dsh-skin-switcher) — 在设置界面新增「皮肤」页，自动发现已安装皮肤并一键切换，支持一键恢复官方默认外观。
 
 ### 💬 会话与消息
 


### PR DESCRIPTION
- [x] My repo's package.json declares **dsh.bundle** (bundle patch ./cordis.patch.yml + web client) / 仓库已声明 dsh.bundle
- [x] One line added to **both** README.en.md (English) and README.md (中文), under Themes & Appearance / 主题与外观
- [x] Description states what the plugin does, no superlatives
- [x] My repo has the dsh-plugin topic

Recommended: published to npm as dsh-skin-switcher (latest 0.2.1). / 已发布 npm 包 dsh-skin-switcher (0.2.1)。