### PR TITLE
add flyingtimes/dsh-trajectory-reader

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -132,6 +132,7 @@ This project actively supports and acknowledges the [LINUX DO](https://linux.do)
 - [Wine-Red/dsh-prompt-stash](https://github.com/Wine-Red/dsh-prompt-stash) - Local, per-session LIFO prompt stash for temporarily setting aside unfinished composer text and safely restoring it later.
 - [dsh-session-search](https://github.com/dsh-external/dsh-session-search) - Index-free read-only search across dsh/Codex/Claude Code/pi/OpenCode sessions.
 
+- [flyingtimes/dsh-trajectory-reader](https://github.com/flyingtimes/dsh-trajectory-reader) - Trajectory interpretation tab: summarizes each user round — what was wanted and how the assistant fulfilled it (needs/thinking/execution/results) via a rules engine plus optional LLM narrative; files, commands and errors at a glance; user messages stay verbatim.
 ### Memory
 
 - [LoserFox/distill](https://github.com/LoserFox/distill) - Automatic conversation distillation: background subagent reflection + skill create/update.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [Wine-Red/dsh-prompt-stash](https://github.com/Wine-Red/dsh-prompt-stash) — 本地、按会话隔离的 LIFO 输入暂存：临时收起未完成的输入，之后安全恢复并继续编辑。
 - [dsh-session-search](https://github.com/dsh-external/dsh-session-search) — 跨 dsh/Codex/Claude Code/pi/OpenCode 会话只读搜索，无索引。
 
+- [flyingtimes/dsh-trajectory-reader](https://github.com/flyingtimes/dsh-trajectory-reader) — 轨迹解读标签页：按用户轮次解读助手做了什么（需求/思路/执行/结果），规则引擎 + 可选 LLM 叙述，文件/命令/错误一目了然，用户消息原样保留。
 ### 🧠 记忆
 
 - [LoserFox/distill](https://github.com/LoserFox/distill) — 自动对话蒸馏：后台 subagent 反省 + 技能 create/update。


### PR DESCRIPTION
Add [dsh-trajectory-reader](https://github.com/flyingtimes/dsh-trajectory-reader) to **💬 会话与消息 / Sessions & Messages** (both zh and en versions).

- A DSH Web client plugin adding a 轨迹解读 tab: per user round it interprets what the assistant did (需求/思路/执行/结果) via a rules engine plus optional LLM narrative; files/commands/errors at a glance; user messages stay verbatim.
- Declares `dsh.bundle.patch` → one-command install: `dsh plugin --profile web add @clarkchan/trajectory-reader`; also on GitHub (flyingtimes/dsh-trajectory-reader).