### PR TITLE
新增 dsh-tool-vision（本地优先视觉插件）

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [Tyan66666/billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) — 模型驱动的上下文压缩：由模型决定何时压缩、压缩什么。
 
 ### 🛠️ 工具与能力
+- [gloryxpnv/dsh-tool-vision](https://github.com/gloryxpnv/dsh-tool-vision) — 为纯文本 DeepSeek Harness 提供本地优先视觉：由本地 VLM（LM Studio / Ollama / vLLM）产出结构化 JSON 证据（OCR / 版面 / 语义），零 API 成本，图片数据完全不出本机。
 - [Gumiho12345/dsh-plugin-net-access](https://github.com/Gumiho12345/dsh-plugin-net-access) — DSH 的 net-access 权限模式：文件写保护不变，沙箱内 curl.exe 可用 HTTPS（Windows）。
 - [xiehuan123/coding-coach](https://github.com/xiehuan123/coding-coach) — Coding Coach 编程教练：面向非开发人员的 35 技能 bundle + 完整 Agent 预设（八段编排流水线 + 工程/产品/界面技能），npm 可装 `dsh plugin add coding-coach`，同时提供 Claude Code 插件。
 - [xiehuan123/dsh-deepread](https://github.com/xiehuan123/dsh-deepread) — DeepRead 精读助手：四种精读模式（含「观点—证据—数据—关系」知识地图与四档置信度）、微信公众号链接 / .pdf 文件（内置纯 JS 提取器）/ 粘贴文本，可选导出 MD / FreeMind 思维导图（XMind 可导入）/ 编辑风网页报告。


### PR DESCRIPTION
新增 [gloryxpnv/dsh-tool-vision](https://github.com/gloryxpnv/dsh-tool-vision) 至「🛠️ 工具与能力」。

为纯文本 DeepSeek Harness 提供本地优先视觉：图片只发送给本地 VLM（LM Studio / Ollama / vLLM / 任意 OpenAI 兼容端点），**零 API 成本、图片数据完全不出本机**。VLM 产出结构化 JSON 证据（`summary` / `ocr` / `layout` / `semantics` / `visual` + 显式 `uncertainty` 列表），主模型基于具体证据作答；反幻觉设计，非法 JSON 回退并明确标注。

- npm 包：`dsh-vision-local` · 安装：`dsh plugin --profile web add dsh-vision-local`
- MIT 协议 · README 中英双语 · topics：`dsh-plugin`、`vision`、`local-first`
