### PR TITLE
docs: add dsh-token-pet

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -46,6 +46,8 @@ This project actively supports and acknowledges the [LINUX DO](https://linux.do)
 
 ### UI Enhancements
 
+- [pk7j7sqryy-ops/dsh-token-pet](https://github.com/pk7j7sqryy-ops/dsh-token-pet) - Cute token-usage widget in the session header: context occupancy, session usage and breakdown, plus date/weekday, weather, 3-day forecast and severe-weather alerts.
+
 - [huiliyi37/dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) - A terminal UI (TUI) for DeepSeek Harness.
 - [openma-ai/deepseek-harness-tui](https://github.com/openma-ai/deepseek-harness-tui) - A Rust/ratatui terminal client that speaks the DSH SDK JSON-RPC protocol directly and runs standalone or as a profile bundle.
 - [omdsh-dev/dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) - Codex-style `@file` mentions: search workspace files in the composer and attach their contents to prompts.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 ## 插件
 
 ### 🎨 UI 增强
+- [pk7j7sqryy-ops/dsh-token-pet](https://github.com/pk7j7sqryy-ops/dsh-token-pet) — 会话头部卡通用量小部件：布布玩偶 + 上下文占用/会话累计/构成，附日期周几、天气、3 天预报与极端天气预警（雨滴/雪花动画），跟随主题色。
+
 - [zealot00/dsh-pet](https://github.com/zealot00/dsh-pet) — DSH Web UI 桌面宠物：精灵图动画、agent 状态联动、拖拽、闹钟（每天/一次）与番茄钟，皮肤下拉选择 + 预览。
 
 - [huiliyi37/dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) — DeepSeek Harness 的终端 UI（TUI）。


### PR DESCRIPTION
Add `dsh-token-pet` — a cute token-usage pet widget for DeepSeek Harness.

- Live context occupancy (progress bar), per-session token usage and context breakdown — reuses host token-meter projections (zero extra requests).
- Date/weekday, realtime weather, 3-day forecast, and severe-weather alerts (rain/snow particles).
- Theme-aware (light/dark), embedded in the session header.
- Dynamic Cordis plugin (Host + Client), MIT licensed.

Repo: https://github.com/pk7j7sqryy-ops/dsh-token-pet