### PR TITLE
Add dsh-speak to Notifications & Integrations

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -278,6 +278,7 @@ This project actively supports and acknowledges the [LINUX DO](https://linux.do)
 - [dsh-feishu-notify](https://github.com/dsh-external/dsh-feishu-notify) - Feishu notifications on session end / input needed.
 - [dsh-notify-windows](https://github.com/SeverusZh/dsh-notify-windows) - Windows notifications, zero dependencies.
 - [dsh-opencode-server](https://github.com/dsh-external/dsh-opencode-server) - Smooth TUI via opencode attach.
+- [Alan2Z/dsh-speak](https://github.com/Alan2Z/dsh-speak) - Voice-announce the final reply on Windows (SAPI5 natural voices) and macOS (system voice); skips reasoning and tool calls, one-line npm install.
 
 ### Models & Providers
 

--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-feishu-notify](https://github.com/dsh-external/dsh-feishu-notify) — 飞书通知（会话结束/等待输入）。
 - [SeverusZh/dsh-notify-windows](https://github.com/SeverusZh/dsh-notify-windows) — Windows 通知，零依赖。
 - [dsh-opencode-server](https://github.com/dsh-external/dsh-opencode-server) — 通过 opencode attach 获得丝滑 TUI。
+- [Alan2Z/dsh-speak](https://github.com/Alan2Z/dsh-speak) — 语音播报 agent 最终回复：Windows SAPI5 自然语音 / macOS 系统语音，自动跳过思考与工具调用，npm 一行安装。
 
 ### 🔌 模型与账号接入
 


### PR DESCRIPTION
Adds [dsh-speak](https://github.com/Alan2Z/dsh-speak) to the Notifications & Integrations category in both README.md and README.en.md.

- package.json declares the dsh.bundle manifest (patch: ./cordis.patch.yml)
- dsh-plugin topic added
- npm package published (dsh-speak)
- Windows (SAPI5 natural voices) + macOS (system voice) engines, event-driven auto-announce of final replies