### PR TITLE
Add JAdpp/dsh-whale-galgame

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -372,6 +372,7 @@ This project actively supports and acknowledges the [LINUX DO](https://linux.do)
 - [sunshine-lang/dsh-weather](https://github.com/sunshine-lang/dsh-weather) - Weather tool via Open-Meteo (free, no API key).
 - [sunshine-lang/dsh-pdf](https://github.com/sunshine-lang/dsh-pdf) - PDF toolbox: extract text, metadata and page ranges via pdfjs-dist.
 - [dsh-ui-whale](https://github.com/dsh-external/dsh-ui-whale) - Pixel whale companion that blinks, wags its tail and spouts hearts.
+- [JAdpp/dsh-whale-galgame](https://github.com/JAdpp/dsh-whale-galgame) - Multi-character Galgame conversation view with separate character and reply-model selection, per-character affection, memory, dialogue history, and CG galleries, plus responses informed by task events across Harness sessions.
 
 ## Related
 

--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [sunshine-lang/dsh-weather](https://github.com/sunshine-lang/dsh-weather) — 天气工具：Open-Meteo 数据（免费，无需 API key）。
 - [sunshine-lang/dsh-pdf](https://github.com/sunshine-lang/dsh-pdf) — PDF 工具箱：基于 pdfjs-dist 提取文本、元数据与页码范围。
 - [dsh-ui-whale](https://github.com/dsh-external/dsh-ui-whale) — 像素鲸鱼伙伴（眨眼/摆尾/喷水/爱心）。
+- [JAdpp/dsh-whale-galgame](https://github.com/JAdpp/dsh-whale-galgame) — 多角色 Galgame 对话界面：角色与回复模型可独立切换，分角色保存好感度、记忆、对话历史与 CG 图鉴，并根据 Harness 跨会话任务事件做出角色回应。
 
 ## 相关
 


### PR DESCRIPTION
## Summary

- Add `JAdpp/dsh-whale-galgame` to the **Just for Fun / 娱乐** category.
- Keep the English and Chinese entries synchronized with a factual description of the plugin.

## Checklist

- [x] The plugin's `package.json` declares `dsh.bundle`.
- [x] One line was added to both `README.en.md` and `README.md` under the matching category.
- [x] The description states functionality without superlatives or marketing language.
- [x] The plugin repository has the `dsh-plugin` topic.

## Validation

- `node scripts/probe-npm.mjs`
- `node scripts/build-site.mjs` — parsed 293 entries across both locales.
- `git diff --check`
