### PR TITLE
docs: add xiaoyanzi191/dsh-premium-themes

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -32,7 +32,7 @@ DeepSeek Harness is DeepSeek's open-source agent harness — a runnable coding a
 
 </details>
 
-**302** plugins · [PRs welcome](#contributing)
+**303** plugins · [PRs welcome](#contributing)
 
 ## Contents
 
@@ -128,6 +128,7 @@ DeepSeek Harness is DeepSeek's open-source agent harness — a runnable coding a
 - [dsh-skins](https://github.com/dsh-external/dsh-skins) - Web UI skins.
 - [BeiZi6/dsh-theme-plugin](https://github.com/BeiZi6/dsh-theme-plugin) - Theme studio for the DSH Web GUI: five built-in presets plus fully customizable light/dark palettes (accent, background, foreground, UI and code fonts, translucent sidebar, contrast), hot-swapped instantly and persisted in localStorage.
 - [zhtx2024/dsh-skin-switcher](https://github.com/zhtx2024/dsh-skin-switcher) - Adds a Skins page to Settings that auto-discovers installed skins for one-click switching, with one-click restore to the official default look.
+- [xiaoyanzi191/dsh-premium-themes](https://github.com/xiaoyanzi191/dsh-premium-themes) - 8 curated color schemes plus custom palette import (name + scheme + seed colors derive a full token map), a Palette row in General settings, hot-plug install.
 
 ### Sessions & Messages
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 
 </details>
 
-**302** 个插件 · 欢迎 [PR](#贡献)
+**303** 个插件 · 欢迎 [PR](#贡献)
 
 ## 目录
 
@@ -128,6 +128,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-skins](https://github.com/dsh-external/dsh-skins) — Web UI 皮肤。
 - [BeiZi6/dsh-theme-plugin](https://github.com/BeiZi6/dsh-theme-plugin) — DSH Web GUI 主题工作室：5 套内置预设 + 完全可自定义的浅/深配色（强调色、背景、前景、UI 与代码字体、半透明侧栏、对比度），即时热切换并持久化到 localStorage。
 - [zhtx2024/dsh-skin-switcher](https://github.com/zhtx2024/dsh-skin-switcher) — 在设置界面新增「皮肤」页，自动发现已安装皮肤并一键切换，支持一键恢复官方默认外观。
+- [xiaoyanzi191/dsh-premium-themes](https://github.com/xiaoyanzi191/dsh-premium-themes) — 8 套精选配色方案与自定义调色板导入（名称+方案+种子色推导完整 token 映射），设置页「调色板」行，热插拔安装。
 
 ### 💬 会话与消息
 


### PR DESCRIPTION
Add [xiaoyanzi191/dsh-premium-themes](https://github.com/xiaoyanzi191/dsh-premium-themes) under Themes & Appearance.

- 8 curated color schemes plus custom palette import (name + scheme + seed colors derive a full token map)
- Palette row in General settings, durable per-plugin persistence, hot-plug install
- Package declares \dsh.bundle\ + \dsh.client\ manifests; repo tagged \dsh-plugin\
- Both README.md (zh) and README.en.md updated; build-site parses 303 entries