### PR TITLE
Add dsh-bell-notify plugin

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -315,6 +315,7 @@ DeepSeek Harness is DeepSeek's open-source agent harness — a runnable coding a
 - [Andyqwe44/dsh-notify-win](https://github.com/Andyqwe44/dsh-notify-win) - Native Windows toast + taskbar flash for task done / approval / ask_user_question, Win10/11, npm install `dsh plugin --profile web add dsh-notify-win`.
 - [dsh-opencode-server](https://github.com/dsh-external/dsh-opencode-server) - Smooth TUI via opencode attach.
 - [cdxiaodong/dsh-island](https://github.com/cdxiaodong/dsh-island) - Bridge DSH agent sessions, tool calls, and approvals to the CodeIsland macOS notch panel over a Unix socket, with in-panel allow/deny.
+- [Laplace-bit/dsh-bell-notify](https://github.com/Laplace-bit/dsh-bell-notify) - Lifecycle bells and a status dot: per-event chimes synthesized live with Web Audio (zero audio files), plus a breathing indicator for agent state.
 
 ### Models & Providers
 

--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [Andyqwe44/dsh-notify-win](https://github.com/Andyqwe44/dsh-notify-win) — 原生 Windows toast + 任务栏闪烁，任务完成/审批/提问时触发，支持 Win10/11，npm 安装 `dsh plugin --profile web add dsh-notify-win`。
 - [dsh-opencode-server](https://github.com/dsh-external/dsh-opencode-server) — 通过 opencode attach 获得丝滑 TUI。
 - [cdxiaodong/dsh-island](https://github.com/cdxiaodong/dsh-island) — 通过 Unix socket 把 DSH agent 的会话、工具调用与审批实时桥接到 CodeIsland macOS 刘海面板，可直接在面板上批准/拒绝。
+- [Laplace-bit/dsh-bell-notify](https://github.com/Laplace-bit/dsh-bell-notify) — 生命周期铃声与状态点：为每个环节合成专属提示音（Web Audio，零音频文件），右下角呼吸状态点显示工作状态。
 
 ### 🔌 模型与账号接入
 


### PR DESCRIPTION
## Summary

Add [dsh-bell-notify](https://github.com/Laplace-bit/dsh-bell-notify) to the **Notifications & Integrations** category:

- **README.md** (中文) and **README.en.md** (English) — one line each.

`dsh-bell-notify` gives the DSH agent "ears and a heartbeat": every lifecycle event (startup, tool call, command, approval wait, turn complete, idle) plays a distinct chime synthesized live with Web Audio — zero audio files shipped — and a breathing status dot in the corner shows what the agent is doing. It declares `dsh.bundle` in `package.json` with a `cordis.patch.yml`, so it installs via `dsh plugin add`.

## Checklist

- [x] One line added to both `README.md` and `README.en.md` under the matching category
- [x] Repo declares `dsh.bundle` manifest in `package.json` (with `cordis.patch.yml`)
- [x] Repo contains real, working code (tests + build in repo)
- [x] [`dsh-plugin`](https://github.com/topics/dsh-plugin) topic added to the repo
- [x] Description states what the plugin does — no marketing