### PR TITLE
Add dsh-unarchive: restore archived sessions

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -155,6 +155,8 @@ DeepSeek Harness is DeepSeek's open-source agent harness — a runnable coding a
 - [futongxu9-maker/dsh-msgrail](https://github.com/futongxu9-maker/dsh-msgrail) - Message-index rail at the conversation's right edge: one brand-colored dot per user message, hover to preview, click to jump, auto-loads older history; pure plugin with no host patching.
 
 
+- [edfrey0044/dsh-unarchive](https://github.com/edfrey0044/dsh-unarchive) - Restore archived sessions: a /unarchive command and an unarchive_session tool that remove sessions from the archive set so they reappear in the workspace at their original position (archiving never deletes data).
+
 ### Memory
 
 - [dsh-context](https://github.com/bowenliang123/dsh-context) - Context insight panel: see what the model's context window is made of and how it evolves — composition vs. window size, per-request history, compression/injection events, and per-message token stats.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [futongxu9-maker/dsh-msgrail](https://github.com/futongxu9-maker/dsh-msgrail) — 对话右缘消息轨道：每条用户消息一个品牌色圆点，悬停预览、点击跳转、自动加载未加载历史，纯插件零宿主侵入。
 
 
+- [edfrey0044/dsh-unarchive](https://github.com/edfrey0044/dsh-unarchive) — 恢复已归档会话：/unarchive 命令与 unarchive_session 工具，把会话移出归档集合、在原位置重新出现在工作区（归档从不删除数据）。
+
 ### 🧠 记忆
 
 - [bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context) — 上下文洞察面板：一眼看清模型上下文窗口的组成与变化——构成对照窗口大小、按请求历史趋势、压缩/注入事件、消息级 token 统计。

--- a/docs/plugins.json
+++ b/docs/plugins.json
@@ -1,4137 +1,4150 @@
 {
- "name": "awesome-dsh-plugin",
- "url": "https://beancookie.github.io/awesome-dsh-plugin",
- "source": "https://github.com/beancookie/awesome-dsh-plugin",
- "updated": "2026-08-16",
- "count": 314,
- "categories": {
-  "ui": {
-   "zh": "UI 增强",
-   "en": "UI Enhancements"
-  },
-  "theme": {
-   "zh": "主题与外观",
-   "en": "Themes & Appearance"
-  },
-  "session": {
-   "zh": "会话与消息",
-   "en": "Sessions & Messages"
-  },
-  "memory": {
-   "zh": "记忆",
-   "en": "Memory"
-  },
-  "tools": {
-   "zh": "工具与能力",
-   "en": "Tools & Capabilities"
-  },
-  "skill": {
-   "zh": "技能包",
-   "en": "Skills"
-  },
-  "workflow": {
-   "zh": "工作流与自动化",
-   "en": "Workflow & Automation"
-  },
-  "notify": {
-   "zh": "通知与集成",
-   "en": "Notifications & Integrations"
-  },
-  "model": {
-   "zh": "模型与账号接入",
-   "en": "Models & Providers"
-  },
-  "dev": {
-   "zh": "开发与运行时",
-   "en": "Development & Runtime"
-  },
-  "fun": {
-   "zh": "娱乐",
-   "en": "Just for Fun"
-  }
- },
- "plugins": [
-  {
-   "name": "dsh-token-pet",
-   "owner": "pk7j7sqryy-ops",
-   "url": "https://github.com/pk7j7sqryy-ops/dsh-token-pet",
-   "category": "ui",
-   "description": {
-    "zh": "会话头部卡通用量小部件：布布玩偶 + 上下文占用/会话累计/构成，附日期周几、天气、3 天预报与极端天气预警（雨滴/雪花动画），跟随主题色。",
-    "en": "Cute token-usage widget in the session header: context occupancy, session usage and breakdown, plus date/weekday, weather, 3-day forecast and severe-weather alerts."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:pk7j7sqryy-ops/dsh-token-pet",
-   "added": "2026-08-15"
-  },
-  {
-   "name": "dsh-pet",
-   "owner": "zealot00",
-   "url": "https://github.com/zealot00/dsh-pet",
-   "category": "ui",
-   "description": {
-    "zh": "DSH Web UI 桌面宠物：精灵图动画、agent 状态联动、拖拽、闹钟（每天/一次）与番茄钟，皮肤下拉选择 + 预览。",
-    "en": "Desktop pet for the DSH Web UI: sprite-sheet animation, agent state linkage, drag, alarm (daily/one-shot) and pomodoro widgets, skin picker with preview."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:zealot00/dsh-pet",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-voice-input-plugin",
-   "owner": "Zhangbo-cn",
-   "url": "https://github.com/Zhangbo-cn/dsh-voice-input-plugin",
-   "category": "ui",
-   "description": {
-    "zh": "输入框麦克风：点击持续监控、按住对话；浏览器语音识别逐字上屏，回复由 host Edge TTS 边生成边朗读（句子切分），朗读时暂停识别防回声，点击可停止。",
-    "en": "Composer microphone: click for continuous monitoring or hold to talk; browser speech recognition types words into the composer as you speak, while replies are read aloud as they stream via host Edge TTS (sentence-split), pausing recognition while reading to avoid echo, click to stop."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Zhangbo-cn/dsh-voice-input-plugin",
-   "added": "2026-08-16"
-  },
-  {
-   "name": "dsh-tianshu-tui",
-   "owner": "huiliyi37",
-   "url": "https://github.com/huiliyi37/dsh-tianshu-tui",
-   "category": "ui",
-   "description": {
-    "zh": "DeepSeek Harness 的终端 UI（TUI）。",
-    "en": "A terminal UI (TUI) for DeepSeek Harness."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:huiliyi37/dsh-tianshu-tui",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "deepseek-harness-tui",
-   "owner": "openma-ai",
-   "url": "https://github.com/openma-ai/deepseek-harness-tui",
-   "category": "ui",
-   "description": {
-    "zh": "Rust/ratatui 终端客户端，直接使用 DSH SDK JSON-RPC 协议，支持独立运行或作为 profile bundle 加载。",
-    "en": "A Rust/ratatui terminal client that speaks the DSH SDK JSON-RPC protocol directly and runs standalone or as a profile bundle."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:openma-ai/deepseek-harness-tui",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-at-file",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/dsh-at-file",
-   "category": "ui",
-   "description": {
-    "zh": "Codex 风格的 `@file` 文件引用，输入框里直接搜索并引用工作区文件。",
-    "en": "Codex-style `@file` mentions: search workspace files in the composer and attach their contents to prompts."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/dsh-at-file",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "ui-status-label",
-   "owner": "alingalingling",
-   "url": "https://github.com/alingalingling/ui-status-label",
-   "category": "ui",
-   "description": {
-    "zh": "把鲸鱼娘思考时的 \"deep diving\" 状态文案自定义成任意你想要的样子。",
-    "en": "Customize the \"deep diving\" thinking status label to anything you like."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:alingalingling/ui-status-label",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-openpencil",
-   "owner": "ZSeven-W",
-   "url": "https://github.com/ZSeven-W/dsh-openpencil",
-   "category": "ui",
-   "description": {
-    "zh": "OpenPencil 设计预览与编辑插件。",
-    "en": "OpenPencil design preview and editing plugin."
-   },
-   "npm": "@zseven-w/dsh-openpencil",
-   "install": "dsh plugin --profile web add @zseven-w/dsh-openpencil",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-visualize",
-   "owner": "Nagi-ovo",
-   "url": "https://github.com/Nagi-ovo/dsh-visualize",
-   "category": "ui",
-   "description": {
-    "zh": "对话内生成式 UI：模型把交互式 HTML 卡片直接画进会话流，带流式预览与沙箱渲染。",
-    "en": "In-conversation generative UI: the model renders interactive HTML cards into the chat stream, with streaming preview and sandboxed rendering."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Nagi-ovo/dsh-visualize",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-side-panel",
-   "owner": "ccq1",
-   "url": "https://github.com/ccq1/dsh-side-panel",
-   "category": "ui",
-   "description": {
-    "zh": "侧边栏集成文件浏览器、终端和 Git 审查，方便预览文件。",
-    "en": "Side panel with file browser, terminal, and Git review for quick file previews."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:ccq1/dsh-side-panel",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-filetree",
-   "owner": "lak321",
-   "url": "https://github.com/lak321/dsh-filetree",
-   "category": "ui",
-   "description": {
-    "zh": "工程文件浏览器：会话视图文件页签，目录树 + VSCode 风格编辑器（C 语法高亮/行号/自动缩进/状态栏），跟随当前工作区。",
-    "en": "Project file browser: per-session file tabs, a directory tree, and a VSCode-style editor (C syntax highlighting, line numbers, auto-indent, status bar) that follows the current workspace."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:lak321/dsh-filetree",
-   "added": "2026-08-16"
-  },
-  {
-   "name": "dsh-focus-chat",
-   "owner": "dingyi222666",
-   "url": "https://github.com/dingyi222666/dsh-focus-chat",
-   "category": "ui",
-   "description": {
-    "zh": "「聚焦会话」精简视图，只关注最终产出结果。",
-    "en": "A \"focus chat\" minimal view that shows only final outputs."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:dingyi222666/dsh-focus-chat",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-genui",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/dsh-genui",
-   "category": "ui",
-   "description": {
-    "zh": "助手回复内渲染交互式 UI 组件：布局、图表、表单、测验、mermaid、3D 场景与回传事件循环。",
-    "en": "Interactive UI components rendered inline in replies: layout, charts, forms, quizzes, mermaid, 3D scenes, and an action event loop back to the model."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/dsh-genui",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-annotation",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/dsh-annotation",
-   "category": "ui",
-   "description": {
-    "zh": "选中文字→批注→随消息发送，回复按批注逐条对照。",
-    "en": "Select text → annotate → send with your message; replies map back to each annotation."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/dsh-annotation",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-navbar",
-   "owner": "vlln",
-   "url": "https://github.com/vlln/dsh-navbar",
-   "category": "ui",
-   "description": {
-    "zh": "对话节点导航条，右缘节点串快速跳转 user 消息。",
-    "en": "Conversation node navigation bar for quick jumps between user messages."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:vlln/dsh-navbar",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-message-preview",
-   "owner": "asukasec",
-   "url": "https://github.com/asukasec/dsh-message-preview",
-   "category": "ui",
-   "description": {
-    "zh": "右侧用户消息导航条，根据消息数量与可用高度自适应排布导航块，并支持悬停预览、键盘操作与点击跳转。",
-    "en": "Right-edge user-message navigator with an adaptive block layout that fits the available height, plus hover previews, keyboard controls, and click-to-jump navigation."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:asukasec/dsh-message-preview",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-task-status",
-   "owner": "vlln",
-   "url": "https://github.com/vlln/dsh-task-status",
-   "category": "ui",
-   "description": {
-    "zh": "后台任务状态条：对话页任务进度 + 实时输出 tail。",
-    "en": "Background task status bar: progress plus live output tail on the chat page."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:vlln/dsh-task-status",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-web-archive",
-   "owner": "renat3u",
-   "url": "https://github.com/renat3u/dsh-web-archive",
-   "category": "ui",
-   "description": {
-    "zh": "折叠对话中的 Think、Bash 等「无用消息」。",
-    "en": "Collapse noisy messages (Think, Bash, etc.) in conversations."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:renat3u/dsh-web-archive",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-spotlight",
-   "owner": "0xsline",
-   "url": "https://github.com/0xsline/dsh-spotlight",
-   "category": "ui",
-   "description": {
-    "zh": "键盘优先的命令面板（command palette）。",
-    "en": "Keyboard-first command palette for the DSH Web UI."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:0xsline/dsh-spotlight",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-101",
-   "owner": "bill9109",
-   "url": "https://github.com/bill9109/dsh-101",
-   "category": "ui",
-   "description": {
-    "zh": "DSH 文档阅读模式。",
-    "en": "Document reading mode for DSH."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:bill9109/dsh-101",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-drag-and-drop",
-   "owner": "bill9109",
-   "url": "https://github.com/bill9109/dsh-drag-and-drop",
-   "category": "ui",
-   "description": {
-    "zh": "跨平台文件拖拽与原始路径插入，无需复制文件。",
-    "en": "Cross-platform file drag-and-drop with raw path insertion, no file copying."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:bill9109/dsh-drag-and-drop",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-file-uploads",
-   "owner": "l541402398",
-   "url": "https://github.com/l541402398/dsh-file-uploads",
-   "category": "ui",
-   "description": {
-    "zh": "从 Web 输入框上传任意本地文件，以待发送卡片展示，并在设置中管理已存文件。",
-    "en": "Upload arbitrary local files from the Web composer, show pending cards, and manage stored files in Settings."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:l541402398/dsh-file-uploads",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-deeplink",
-   "owner": "qyw233",
-   "url": "https://github.com/qyw233/dsh-deeplink",
-   "category": "ui",
-   "description": {
-    "zh": "`?session=` / `?workspace=` 深链直达指定项目对话。",
-    "en": "Deep links: open a specific session or workspace via `?session=` / `?workspace=`."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:qyw233/dsh-deeplink",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-diff-viewer",
-   "owner": "lehhair",
-   "url": "https://github.com/lehhair/dsh-diff-viewer",
-   "category": "ui",
-   "description": {
-    "zh": "PiUI 风格 diff 查看器，替换 write/edit 工具调用的默认 DiffBlock。",
-    "en": "PiUI-style diff viewer replacing the stock DiffBlock for write/edit tool calls."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:lehhair/dsh-diff-viewer",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "ex-setting",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/ex-setting",
-   "category": "ui",
-   "description": {
-    "zh": "DSH 的设置扩展。",
-    "en": "Settings extensions for DSH."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/ex-setting",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "web-components",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/web-components",
-   "category": "ui",
-   "description": {
-    "zh": "Web Components 支持。",
-    "en": "Web Components support."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/web-components",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-turn-navigator",
-   "owner": "vibeinging",
-   "url": "https://github.com/vibeinging/dsh-turn-navigator",
-   "category": "ui",
-   "description": {
-    "zh": "对话轮次导航。",
-    "en": "Turn navigation for the DSH Web UI."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:vibeinging/dsh-turn-navigator",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-milestone",
-   "owner": "SnowCrescenter-tech",
-   "url": "https://github.com/SnowCrescenter-tech/dsh-milestone",
-   "category": "ui",
-   "description": {
-    "zh": "右侧圆点时间轴导航条，点击跳转到任意用户消息。",
-    "en": "Right-side dot-timeline rail: jump between user messages."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:SnowCrescenter-tech/dsh-milestone",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-balance-meter",
-   "owner": "Ghost011118",
-   "url": "https://github.com/Ghost011118/dsh-balance-meter",
-   "category": "ui",
-   "description": {
-    "zh": "输入框 dock 显示 DeepSeek 账户余额与会话花费，自动拉取官方定价，支持高峰/低谷计价。",
-    "en": "DeepSeek account balance and session cost in the composer dock, with auto-fetched official pricing and peak/off-peak support."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Ghost011118/dsh-balance-meter",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-opencode-go-usage",
-   "owner": "v587d",
-   "url": "https://github.com/v587d/dsh-opencode-go-usage",
-   "category": "ui",
-   "description": {
-    "zh": "在输入框上方 dock 显示 OpenCode Go 订阅用量（5h 滚动/每周/每月窗口与重置倒计时），内置凭据编辑器。",
-    "en": "OpenCode Go subscription usage (rolling/weekly/monthly windows with reset countdowns) in the composer dock, with a built-in credential editor."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:v587d/dsh-opencode-go-usage",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-cost-meter",
-   "owner": "Han-1413141",
-   "url": "https://github.com/Han-1413141/dsh-cost-meter",
-   "category": "ui",
-   "description": {
-    "zh": "会话与当日 API 费用统计、预算图框（已用%）、官方余额、历史看板，支持峰谷计价与官方价格一键同步。",
-    "en": "Per-session and daily API cost, budget with usage %, official balance, history dashboard, and one-click official price sync with peak/off-peak pricing."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Han-1413141/dsh-cost-meter",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-plugin-deepseek-balance",
-   "owner": "fishxcode",
-   "url": "https://github.com/fishxcode/dsh-plugin-deepseek-balance",
-   "category": "ui",
-   "description": {
-    "zh": "在 DSH Web 设置中展示 DeepSeek API 余额、余额趋势与每日用量图表。",
-    "en": "DeepSeek API balance, balance trend, and daily usage charts in DSH Web settings."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:fishxcode/dsh-plugin-deepseek-balance",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "ds-api-usage",
-   "owner": "Sev7een",
-   "url": "https://github.com/Sev7een/ds-api-usage",
-   "category": "ui",
-   "description": {
-    "zh": "在设置页展示 DeepSeek API 余额与最近 24 小时用量，包括估算消费、Token、请求次数和按小时时间线。",
-    "en": "DeepSeek API balance and 24-hour usage dashboard in Settings, with estimated spend, token counts, request counts, and an hourly timeline."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Sev7een/ds-api-usage",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-spend",
-   "owner": "nonewind",
-   "url": "https://github.com/nonewind/dsh-spend",
-   "category": "ui",
-   "description": {
-    "zh": "DSH Web 用量与费用统计插件：右下角悬浮窗，按模型/按天/按会话多维聚合与预计花费。",
-    "en": "Token usage and estimated spend for the dsh web UI: floating panel with per-model, per-day, and per-session stats."
-   },
-   "npm": "dsh-spend",
-   "install": "dsh plugin --profile web add dsh-spend",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-deepseek-balance",
-   "owner": "lancecheney",
-   "url": "https://github.com/lancecheney/dsh-plugins/tree/main/packages/dsh-deepseek-balance",
-   "category": "ui",
-   "description": {
-    "zh": "Session log 按钮左侧的实时计费徽章：余额、每会话消耗、峰谷/平价价格，按模型/货币/思考强度自动切换，每天抓官方定价。",
-    "en": "A real-time billing badge left of the Session log button: balance, per-conversation spend, peak/off-peak/flat pricing, auto-switching by model/currency/effort, daily official pricing fetch."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:lancecheney/dsh-plugins/tree/main/packages/dsh-deepseek-balance",
-   "added": "2026-08-15"
-  },
-  {
-   "name": "dsh-TUI",
-   "owner": "ccch1mneyyy",
-   "url": "https://github.com/ccch1mneyyy/dsh-TUI",
-   "category": "ui",
-   "description": {
-    "zh": "Claude Code 风格全屏终端 UI：像素鲸鱼顶栏、实时工作状态行、思考流式展开。",
-    "en": "Claude Code-style full-screen terminal UI: pixel-whale header, live status line, and streaming thought expansion."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:ccch1mneyyy/dsh-TUI",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "DSH-better-sidebar",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/DSH-better-sidebar",
-   "category": "ui",
-   "description": {
-    "zh": "侧边栏完整工作台：内置文件渲染编辑、终端、Git 与子代理，支持三方插件注册新 Tab。",
-    "en": "Full sidebar workbench with file rendering and editing, terminal, Git, and subagents; third-party plugins can register new tabs."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/DSH-better-sidebar",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-sticky-disclosure",
-   "owner": "Han-1413141",
-   "url": "https://github.com/Han-1413141/dsh-sticky-disclosure",
-   "category": "ui",
-   "description": {
-    "zh": "一键收起会话中所有展开的区块（Think、工具卡等），常驻计数按钮 + 自定义快捷键。",
-    "en": "One-click collapse of every expanded section (Think rows, tool cards) with a live-count pill and a customizable hotkey."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Han-1413141/dsh-sticky-disclosure",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-sticky-note",
-   "owner": "Meredith2328",
-   "url": "https://github.com/Meredith2328/dsh-sticky-note",
-   "category": "ui",
-   "description": {
-    "zh": "编辑框工具栏便签，随手记点子和 TODO，自动保存为 Markdown，一键发送到对话。",
-    "en": "Quick sticky notes on the composer toolbar: jot ideas or TODOs, auto-saved as Markdown, one click to send into the chat."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Meredith2328/dsh-sticky-note",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-web-attention-badge",
-   "owner": "Luaphes",
-   "url": "https://github.com/Luaphes/dsh-web-attention-badge",
-   "category": "ui",
-   "description": {
-    "zh": "会话需要你时三处同时亮起：角标、标签页标题计数、按状态换色的鲸鱼 favicon。",
-    "en": "Attention reminders: frame badge, tab-title count, and a status-colored whale favicon for sessions waiting for input or finished unopened."
-   },
-   "npm": "dsh-web-attention-badge",
-   "install": "dsh plugin --profile web add dsh-web-attention-badge",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-web-ui",
-   "owner": "zhu1090093659",
-   "url": "https://github.com/zhu1090093659/dsh-web-ui",
-   "category": "ui",
-   "description": {
-    "zh": "DSH Web UI 插件与皮肤合集：任务看板、git 图、右侧面板、远程移动端 UI、桌宠、实时 token 统计与皮肤中心。",
-    "en": "Plugin and skin collection for the DSH Web UI: task board, Git graph, right-side panel, remote mobile UI, pet, live token stats, and a skin center."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:zhu1090093659/dsh-web-ui",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-builtin-toggles",
-   "owner": "Starfie1d1272",
-   "url": "https://github.com/Starfie1d1272/dsh-builtin-toggles",
-   "category": "ui",
-   "description": {
-    "zh": "为 DSH Web 添加官方内置插件目录、搜索与状态说明，并提供经过审核的安全 UI 插件开关。",
-    "en": "Adds a built-in plugin catalog to DSH Web with search, status explanations, and safe toggles for audited UI plugins."
-   },
-   "npm": "dsh-builtin-toggles",
-   "install": "dsh plugin --profile web add dsh-builtin-toggles",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-ux",
-   "owner": "jiangnanquan",
-   "url": "https://github.com/jiangnanquan/dsh-ux",
-   "category": "ui",
-   "description": {
-    "zh": "Solarized 浅色主题、紧凑布局、思考/工具链折叠胶囊，以及余额、本轮成本与用量看板的 DSH Web 界面增强插件。",
-    "en": "Solarized light theme, compact layout, think/tool-chain collapse capsules, and balance, session cost, and usage dashboards for the DSH web UI."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:jiangnanquan/dsh-ux",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-hud",
-   "owner": "a903067276-rgb",
-   "url": "https://github.com/a903067276-rgb/dsh-hud",
-   "category": "ui",
-   "description": {
-    "zh": "HUD 状态面板：Git 状态、MCP 服务器、技能列表、模型与 token 用量，悬浮侧栏一览无余。",
-    "en": "HUD status panel: Git status, MCP servers, skills, model and token usage in a floating side panel."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:a903067276-rgb/dsh-hud",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-plugins#turn-scrubber",
-   "owner": "wsxwj123",
-   "url": "https://github.com/wsxwj123/dsh-plugins/tree/main/packages/turn-scrubber",
-   "category": "ui",
-   "description": {
-    "zh": "右侧紧凑回合刻度条，悬停显示回合摘要，点击跳转到对应用户回合。",
-    "en": "Compact right-edge turn rail with hover summaries and click-to-jump navigation."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:wsxwj123/dsh-plugins/tree/main/packages/turn-scrubber",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-cost-meter",
-   "owner": "Sttrevens",
-   "url": "https://github.com/Sttrevens/dsh-cost-meter",
-   "category": "ui",
-   "description": {
-    "zh": "Web UI 美元成本徽标：头部显示会话总成本、每条回复结尾显示该轮成本，悬停看分项。",
-    "en": "Per-turn USD cost badge in the Web UI: session total in the header and per-turn cost in each message footer, with a hover breakdown."
-   },
-   "npm": "@steven-wu/dsh-cost-meter",
-   "install": "dsh plugin --profile web add @steven-wu/dsh-cost-meter",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-file-mentions",
-   "owner": "a903067276-rgb",
-   "url": "https://github.com/a903067276-rgb/dsh-file-mentions",
-   "category": "ui",
-   "description": {
-    "zh": "DSH 回复中的文件路径可点击：Codex 风格行内打开、文件管理器定位、回合尾部文件 chip 列表。",
-    "en": "Clickable file paths in DSH replies: Codex-style inline open, reveal in file manager, and a mentioned-files chip list at the turn tail."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:a903067276-rgb/dsh-file-mentions",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-calculator",
-   "owner": "bobcat848",
-   "url": "https://github.com/bobcat848/dsh-calculator",
-   "category": "ui",
-   "description": {
-    "zh": "右侧面板展示 DeepSeek API 费用（当前会话 + 全部会话累计）与账户余额，内置官方计价与峰谷计价支持。",
-    "en": "DeepSeek API spend (current session and all sessions) and account balance in the aside panel, with official pricing and peak/off-peak support."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:bobcat848/dsh-calculator",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-deepseek-billing",
-   "owner": "Jolly-J",
-   "url": "https://github.com/Jolly-J/dsh-deepseek-billing",
-   "category": "ui",
-   "description": {
-    "zh": "侧边栏底部 DeepSeek 账户余额显示与会话费用估算卡片。",
-    "en": "DeepSeek account balance and per-session cost card in the sidebar foot."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Jolly-J/dsh-deepseek-billing",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-drag-and-drop",
-   "owner": "AKIRACOD",
-   "url": "https://github.com/AKIRACOD/dsh-drag-and-drop",
-   "category": "ui",
-   "description": {
-    "zh": "拖放 fork：文档以可删除「文件芯片」挂在输入框上方，不打字也能发送。",
-    "en": "File-drag fork: drop documents as removable chips above the composer, send without typing."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:AKIRACOD/dsh-drag-and-drop",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "context-vista",
-   "owner": "GooodWei",
-   "url": "https://github.com/GooodWei/context-vista",
-   "category": "ui",
-   "description": {
-    "zh": "右侧悬浮面板，环形图实时展示上下文 token 用量与费用。",
-    "en": "Right-side floating panel with a live donut chart of context token usage and cost."
-   },
-   "npm": "context-vista",
-   "install": "dsh plugin --profile web add context-vista",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-paste-input",
-   "owner": "dsh-external",
-   "url": "https://github.com/dsh-external/dsh-paste-input",
-   "category": "ui",
-   "description": {
-    "zh": "Ctrl+V 粘贴文件 / 拖拽 / 选择。",
-    "en": "Ctrl+V paste files / drag & drop / picker."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:dsh-external/dsh-paste-input",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-web-billing",
-   "owner": "bpc-oss",
-   "url": "https://github.com/bpc-oss/dsh-web-billing",
-   "category": "ui",
-   "description": {
-    "zh": "人民币/美元 token 计费，官方政策计价与逐条消息费用账本。",
-    "en": "RMB/USD token billing with official-policy pricing and a per-message cost ledger."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:bpc-oss/dsh-web-billing",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-pi-tui",
-   "owner": "lqhl",
-   "url": "https://github.com/lqhl/dsh-pi-tui",
-   "category": "ui",
-   "description": {
-    "zh": "差分渲染 TUI 前端：流式 Markdown 与工具卡片。",
-    "en": "Differential-rendering TUI front end with streaming markdown and tool cards."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:lqhl/dsh-pi-tui",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-web-panel",
-   "owner": "dsh-external",
-   "url": "https://github.com/dsh-external/dsh-web-panel",
-   "category": "ui",
-   "description": {
-    "zh": "内嵌终端 dock + Git Review + 文件视图。",
-    "en": "Embedded terminal dock + Git review + file view."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:dsh-external/dsh-web-panel",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-web-review",
-   "owner": "CanglongCl",
-   "url": "https://github.com/CanglongCl/dsh-web-review",
-   "category": "ui",
-   "description": {
-    "zh": "隔离网页预览，通过元素批注指导源码修改。",
-    "en": "Isolated web page previews with element annotations that guide source edits."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:CanglongCl/dsh-web-review",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-plugin-workshop",
-   "owner": "yyyyukari",
-   "url": "https://github.com/yyyyukari/dsh-plugin-workshop",
-   "category": "ui",
-   "description": {
-    "zh": "创意工坊式插件浏览器：一键安装/更新/卸载。",
-    "en": "Steam Workshop-style in-app plugin browser with one-click install/update/uninstall."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:yyyyukari/dsh-plugin-workshop",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-turn-index",
-   "owner": "Simon314620",
-   "url": "https://github.com/Simon314620/dsh-turn-index",
-   "category": "ui",
-   "description": {
-    "zh": "轮次索引侧边栏，滚动时自动高亮当前轮次。",
-    "en": "Turn-index sidebar with scroll-spy highlighting."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Simon314620/dsh-turn-index",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-plugin-description",
-   "owner": "MysaDC",
-   "url": "https://github.com/MysaDC/dsh-plugin-description",
-   "category": "ui",
-   "description": {
-    "zh": "为 Web 设置页插件卡片补上中英文功能说明。",
-    "en": "Bilingual descriptions on every plugin card in the Web Settings plugin list."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:MysaDC/dsh-plugin-description",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-opencodego-usage",
-   "owner": "BeiZi6",
-   "url": "https://github.com/BeiZi6/dsh-opencodego-usage",
-   "category": "ui",
-   "description": {
-    "zh": "OpenCodeGo 剩余额度监视器：输入框右下角呼吸指示灯（按剩余额度绿/黄/红），液态玻璃面板显示滚动/周/月用量窗口与重置时间，每 30 秒自动刷新，API Key 自动读取 DSH 凭据。",
-    "en": "OpenCodeGo quota monitor for the DSH Web GUI: a breathing indicator at the input's bottom-right (green/yellow/red by remaining share), a liquid-glass panel with rolling/weekly/monthly usage windows and reset times, auto-refreshing every 30 s; API key read from DSH credentials."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:BeiZi6/dsh-opencodego-usage",
-   "added": "2026-08-15"
-  },
-  {
-   "name": "dsh-galgame",
-   "owner": "Lanxing6480",
-   "url": "https://github.com/Lanxing6480/dsh-galgame",
-   "category": "ui",
-   "description": {
-    "zh": "DSH Web 聊天界面 GalGame 演出层：立绘差分、流式思考气泡、打字机对话框与 GalGame 式提问/审批选项框，可随时切回普通聊天。",
-    "en": "A visual-novel presentation layer for the DSH Web chat view: portrait diffs, streaming thought bubble, typewriter dialogue, and GalGame-style question/approval panels; switch back to the normal chat anytime."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Lanxing6480/dsh-galgame",
-   "added": "2026-08-15"
-  },
-  {
-   "name": "dsh-smooth-stream",
-   "owner": "Laplace-bit",
-   "url": "https://github.com/Laplace-bit/dsh-smooth-stream",
-   "category": "ui",
-   "description": {
-    "zh": "丝滑流式渲染：字跟着模型到达走、换行滑入、不闪，滚动归用户，尊重 `prefers-reduced-motion`。",
-    "en": "Silky streaming reveal for the Web UI: text appears at the model's arrival rate, new lines glide in, no flicker; follow stays with the user and `prefers-reduced-motion` is respected."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Laplace-bit/dsh-smooth-stream",
-   "added": "2026-08-16"
-  },
-  {
-   "name": "dsh-skin",
-   "owner": "KinGao294",
-   "url": "https://github.com/KinGao294/dsh-skin",
-   "category": "theme",
-   "description": {
-    "zh": "Codex 风格皮肤切换器 + 自定义壁纸层，可调透明度与模糊。",
-    "en": "Codex-style skin switcher plus a custom wallpaper layer with opacity and blur controls."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:KinGao294/dsh-skin",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-deep-whale",
-   "owner": "Small-tailqwq",
-   "url": "https://github.com/Small-tailqwq/dsh-deep-whale",
-   "category": "theme",
-   "description": {
-    "zh": "DSH Web 鲸鱼娘皮肤系列（深海女仆工坊 maid-atelier）。",
-    "en": "Whale-girl skin series for the DSH Web UI (maid-atelier)."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Small-tailqwq/dsh-deep-whale",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-plugins#theme-gallery",
-   "owner": "wsxwj123",
-   "url": "https://github.com/wsxwj123/dsh-plugins/tree/main/packages/theme-gallery",
-   "category": "theme",
-   "description": {
-    "zh": "15 个精选主题家族，浅深配色完整，跟随 DSH 原生浅色/深色/跟随系统模式。",
-    "en": "Fifteen curated theme families with complete light and dark palettes that follow the native Light, Dark, and Follow system modes."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:wsxwj123/dsh-plugins/tree/main/packages/theme-gallery",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-skins",
-   "owner": "dsh-external",
-   "url": "https://github.com/dsh-external/dsh-skins",
-   "category": "theme",
-   "description": {
-    "zh": "Web UI 皮肤。",
-    "en": "Web UI skins."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:dsh-external/dsh-skins",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-theme-plugin",
-   "owner": "BeiZi6",
-   "url": "https://github.com/BeiZi6/dsh-theme-plugin",
-   "category": "theme",
-   "description": {
-    "zh": "DSH Web GUI 主题工作室：5 套内置预设 + 完全可自定义的浅/深配色（强调色、背景、前景、UI 与代码字体、半透明侧栏、对比度），即时热切换并持久化到 localStorage。",
-    "en": "Theme studio for the DSH Web GUI: five built-in presets plus fully customizable light/dark palettes (accent, background, foreground, UI and code fonts, translucent sidebar, contrast), hot-swapped instantly and persisted in localStorage."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:BeiZi6/dsh-theme-plugin",
-   "added": "2026-08-15"
-  },
-  {
-   "name": "dsh-skin-switcher",
-   "owner": "zhtx2024",
-   "url": "https://github.com/zhtx2024/dsh-skin-switcher",
-   "category": "theme",
-   "description": {
-    "zh": "在设置界面新增「皮肤」页，自动发现已安装皮肤并一键切换，支持一键恢复官方默认外观。",
-    "en": "Adds a Skins page to Settings that auto-discovers installed skins for one-click switching, with one-click restore to the official default look."
-   },
-   "npm": "dsh-skin-switcher",
-   "install": "dsh plugin --profile web add dsh-skin-switcher",
-   "added": "2026-08-15"
-  },
-  {
-   "name": "dsh-premium-themes",
-   "owner": "xiaoyanzi191",
-   "url": "https://github.com/xiaoyanzi191/dsh-premium-themes",
-   "category": "theme",
-   "description": {
-    "zh": "8 套精选配色方案与自定义调色板导入（名称+方案+种子色推导完整 token 映射），设置页「调色板」行，热插拔安装。",
-    "en": "8 curated color schemes plus custom palette import (name + scheme + seed colors derive a full token map), a Palette row in General settings, hot-plug install."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:xiaoyanzi191/dsh-premium-themes",
-   "added": "2026-08-16"
-  },
-  {
-   "name": "dsh-theme-kit",
-   "owner": "ink5897",
-   "url": "https://github.com/ink5897/dsh-theme-kit",
-   "category": "theme",
-   "description": {
-    "zh": "32 款预设主题（莫兰迪 / 马卡龙 / 中国传统色）、动态与静态壁纸、纸纹纹理、分区透明度与文字深浅，附按键桌宠。",
-    "en": "32 preset themes across three palettes (Morandi, Macaron, Chinese traditional), animated and static wallpapers, paper textures, per-zone opacity and text depth, plus a keyboard desktop pet."
-   },
-   "npm": "dsh-theme-kit",
-   "install": "dsh plugin --profile web add dsh-theme-kit",
-   "added": "2026-08-16"
-  },
-  {
-   "name": "dsh-turn-rewind",
-   "owner": "Anionex",
-   "url": "https://github.com/Anionex/dsh-turn-rewind",
-   "category": "session",
-   "description": {
-    "zh": "对话回退：基于持久 Change Ledger 回滚会话与工作区状态。",
-    "en": "Rewind conversation and workspace state, powered by a persistent Change Ledger."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Anionex/dsh-turn-rewind",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-crosstalk",
-   "owner": "Jesse-njx",
-   "url": "https://github.com/Jesse-njx/dsh-crosstalk",
-   "category": "session",
-   "description": {
-    "zh": "跨会话消息：本机任意会话都可像 Claude Code 一样列出并互发消息，基于本地心跳注册表与收件箱。",
-    "en": "Cross-session messaging for DSH: any session on the machine can list and message any other, Claude Code-style, via a local heartbeat registry and inbox."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Jesse-njx/dsh-crosstalk",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-share",
-   "owner": "hellodigua",
-   "url": "https://github.com/hellodigua/dsh-share",
-   "category": "session",
-   "description": {
-    "zh": "一键分享你的对话。",
-    "en": "Share your conversations with one click."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:hellodigua/dsh-share",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-message-edit",
-   "owner": "Moeblack",
-   "url": "https://github.com/Moeblack/dsh-message-edit",
-   "category": "session",
-   "description": {
-    "zh": "基于分支的消息编辑、reroll、重试与版本时间线。",
-    "en": "Branch-based message editing, reroll, retry, and a version timeline."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Moeblack/dsh-message-edit",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-sidechain",
-   "owner": "Buyi-wsgzg",
-   "url": "https://github.com/Buyi-wsgzg/dsh-sidechain",
-   "category": "session",
-   "description": {
-    "zh": "`/side` 持续性侧会话与 `/btw` 一次性侧问，在临时 fork 中运行、不写入主会话历史。",
-    "en": "`/side` persistent side sessions and `/btw` one-shot side questions, run in a temporary fork without touching main history."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Buyi-wsgzg/dsh-sidechain",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-conversation-share",
-   "owner": "bill9109",
-   "url": "https://github.com/bill9109/dsh-conversation-share",
-   "category": "session",
-   "description": {
-    "zh": "分享任意段落的对话。",
-    "en": "Share any excerpt of a conversation."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:bill9109/dsh-conversation-share",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-explain",
-   "owner": "yuezengwu",
-   "url": "https://github.com/yuezengwu/dsh-explain",
-   "category": "session",
-   "description": {
-    "zh": "本地优先学习模式：跨会话全局学习线程、按来源讲解。",
-    "en": "Local-first learning mode: cross-session learning threads with per-source explanations."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:yuezengwu/dsh-explain",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-prompt-studio",
-   "owner": "Moeblack",
-   "url": "https://github.com/Moeblack/dsh-prompt-studio",
-   "category": "session",
-   "description": {
-    "zh": "带实时预览的用户/内置 system prompt 分节编辑器。",
-    "en": "Edit user and built-in system-prompt sections with live preview."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Moeblack/dsh-prompt-studio",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-peer-link",
-   "owner": "czm15053",
-   "url": "https://github.com/czm15053/dsh-peer-link",
-   "category": "session",
-   "description": {
-    "zh": "让 dsh 和 Claude Code 会话直接互发消息，附带可点击的会话列表卡片（搜索/刷新/弹窗发送）。",
-    "en": "Let dsh and Claude Code sessions message each other directly; comes with a clickable peer list card (sort/search/send/refresh)."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:czm15053/dsh-peer-link",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-chat-import",
-   "owner": "Nwflower",
-   "url": "https://github.com/Nwflower/dsh-chat-import",
-   "category": "session",
-   "description": {
-    "zh": "把 Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / opencode 的聊天记录全保真导入为可续聊的 DSH 会话。",
-    "en": "Import Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / opencode chat histories as resumable DeepSeek Harness sessions."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Nwflower/dsh-chat-import",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-file-claim",
-   "owner": "Nwflower",
-   "url": "https://github.com/Nwflower/dsh-file-claim",
-   "category": "session",
-   "description": {
-    "zh": "同一工作区并行多会话的文件认领与写入保护（claim/release、心跳 stale 接管、pending 三路合并）。",
-    "en": "File claim/release protection for parallel DSH sessions on the same workspace (heartbeat stale takeover, pending 3-way merge area)."
-   },
-   "npm": "dsh-file-claim",
-   "install": "dsh plugin --profile web add dsh-file-claim",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-interconnect",
-   "owner": "Chinesezjc",
-   "url": "https://github.com/Chinesezjc/dsh-interconnect",
-   "category": "session",
-   "description": {
-    "zh": "跨实例互联：经 interconnect 服务在多个 DSH 实例间转发消息与事件。",
-    "en": "Cross-instance message and event handoff between DSH instances via an interconnect server."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Chinesezjc/dsh-interconnect",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-prompt-stash",
-   "owner": "Wine-Red",
-   "url": "https://github.com/Wine-Red/dsh-prompt-stash",
-   "category": "session",
-   "description": {
-    "zh": "本地、按会话隔离的 LIFO 输入暂存：临时收起未完成的输入，之后安全恢复并继续编辑。",
-    "en": "Local, per-session LIFO prompt stash for temporarily setting aside unfinished composer text and safely restoring it later."
-   },
-   "npm": "dsh-prompt-stash",
-   "install": "dsh plugin --profile web add dsh-prompt-stash",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-session-search",
-   "owner": "dsh-external",
-   "url": "https://github.com/dsh-external/dsh-session-search",
-   "category": "session",
-   "description": {
-    "zh": "跨 dsh/Codex/Claude Code/pi/OpenCode 会话只读搜索，无索引。",
-    "en": "Index-free read-only search across dsh/Codex/Claude Code/pi/OpenCode sessions."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:dsh-external/dsh-session-search",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-trajectory-reader",
-   "owner": "flyingtimes",
-   "url": "https://github.com/flyingtimes/dsh-trajectory-reader",
-   "category": "session",
-   "description": {
-    "zh": "轨迹解读标签页：按用户轮次解读助手做了什么（需求/思路/执行/结果），规则引擎 + 可选 LLM 叙述，文件/命令/错误一目了然，用户消息原样保留。",
-    "en": "Trajectory interpretation tab: summarizes each user round — what was wanted and how the assistant fulfilled it (needs/thinking/execution/results) via a rules engine plus optional LLM narrative; files, commands and errors at a glance; user messages stay verbatim."
-   },
-   "npm": "@clarkchan/trajectory-reader",
-   "install": "dsh plugin --profile web add @clarkchan/trajectory-reader",
-   "added": "2026-08-15"
-  },
-  {
-   "name": "dsh-msgrail",
-   "owner": "futongxu9-maker",
-   "url": "https://github.com/futongxu9-maker/dsh-msgrail",
-   "category": "session",
-   "description": {
-    "zh": "对话右缘消息轨道：每条用户消息一个品牌色圆点，悬停预览、点击跳转、自动加载未加载历史，纯插件零宿主侵入。",
-    "en": "Message-index rail at the conversation's right edge: one brand-colored dot per user message, hover to preview, click to jump, auto-loads older history; pure plugin with no host patching."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:futongxu9-maker/dsh-msgrail",
-   "added": "2026-08-16"
-  },
-  {
-   "name": "dsh-context",
-   "owner": "bowenliang123",
-   "url": "https://github.com/bowenliang123/dsh-context",
-   "category": "memory",
-   "description": {
-    "zh": "上下文洞察面板：一眼看清模型上下文窗口的组成与变化——构成对照窗口大小、按请求历史趋势、压缩/注入事件、消息级 token 统计。",
-    "en": "Context insight panel: see what the model's context window is made of and how it evolves — composition vs. window size, per-request history, compression/injection events, and per-message token stats."
-   },
-   "npm": "dsh-context",
-   "install": "dsh plugin --profile web add dsh-context",
-   "added": "2026-08-16"
-  },
-  {
-   "name": "distill",
-   "owner": "LoserFox",
-   "url": "https://github.com/LoserFox/distill",
-   "category": "memory",
-   "description": {
-    "zh": "自动对话蒸馏：后台 subagent 反省 + 技能 create/update。",
-    "en": "Automatic conversation distillation: background subagent reflection + skill create/update."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:LoserFox/distill",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-mnemon",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/dsh-mnemon",
-   "category": "memory",
-   "description": {
-    "zh": "Mnemon 深度集成：本地三层记忆（Runtime Memory、可检索 Documents、受监督 Memory Spaces）。",
-    "en": "Deep Mnemon integration: local three-tier memory (Runtime Memory, retrievable Documents, supervised Memory Spaces)."
-   },
-   "npm": "dsh-mnemon",
-   "install": "dsh plugin --profile web add dsh-mnemon",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-mneme",
-   "owner": "modusensus",
-   "url": "https://github.com/modusensus/dsh-mneme",
-   "category": "memory",
-   "description": {
-    "zh": "跨会话记忆：SQLite + 可人工编辑的 Markdown 镜像，后台自动巩固（去重/合并/冲突裁决），提供 6 个记忆工具。",
-    "en": "Cross-session memory: SQLite with a human-editable Markdown mirror, background consolidation (dedup, merge, conflict resolution), and six memory tools."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:modusensus/dsh-mneme",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "nowledge-mem-deepseek-harness",
-   "owner": "nowledge-co",
-   "url": "https://github.com/nowledge-co/nowledge-mem-deepseek-harness",
-   "category": "memory",
-   "description": {
-    "zh": "给所有 AI 工具和 Agent 共用的一层记忆：注入 Context Bundle、提示时检索、MCP 工具与回合结束 DSH 线程捕获。",
-    "en": "One memory layer for every AI tool and agent: Context Bundle injection, prompt-time recall, MCP tools, and turn-end DSH thread capture."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:nowledge-co/nowledge-mem-deepseek-harness",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-memory",
-   "owner": "Jesse-njx",
-   "url": "https://github.com/Jesse-njx/dsh-memory",
-   "category": "memory",
-   "description": {
-    "zh": "基于 DSH 无损会话日志的引用式记忆：蒸馏出的事实带 `(sessionId, eventRange)` 引用，可随时展开回原始日志片段。",
-    "en": "Cited memory over DSH's lossless session log: distilled facts carry `(sessionId, eventRange)` citations that expand back to the exact original log excerpt."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Jesse-njx/dsh-memory",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-memory",
-   "owner": "flymysql",
-   "url": "https://github.com/flymysql/dsh-memory",
-   "category": "memory",
-   "description": {
-    "zh": "跨会话记忆库：remember / recall / forget 工具、每轮提示注入与设置页条目浏览。",
-    "en": "Cross-session memory vault: remember / recall / forget tools, per-turn prompt injection, and a settings-page entry browser."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:flymysql/dsh-memory",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-plugin-asmemory",
-   "owner": "Xplore-LAB",
-   "url": "https://github.com/Xplore-LAB/dsh-plugin-asmemory",
-   "category": "memory",
-   "description": {
-    "zh": "动作-状态时序记忆：记录类型化的状态与动作，做趋势、异常与因果关联分析。",
-    "en": "Action-state time memory: record typed states and actions, then analyze trends, anomalies, and causality."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Xplore-LAB/dsh-plugin-asmemory",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-memento",
-   "owner": "PerryLink",
-   "url": "https://github.com/PerryLink/dsh-memento",
-   "category": "memory",
-   "description": {
-    "zh": "有界、分层、带审批门、可审计的跨会话记忆：`ctx.memory` 服务 + 零依赖 SQLite 存储 + `memory` 工具与冻结快照注入；写入必过审批门，模型可见内容可自会话日志重建。",
-    "en": "Bounded, layered, approval-gated, auditable cross-session memory: a typed `ctx.memory` seam with a zero-dependency SQLite provider, a `memory` tool, and frozen snapshot injection; every write passes the approval gate and stays reconstructable from the session log."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:PerryLink/dsh-memento",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-file-memory",
-   "owner": "ICCuse",
-   "url": "https://github.com/ICCuse/dsh-file-memory",
-   "category": "memory",
-   "description": {
-    "zh": "文件型工作记忆：memorize/recall 把关键前提逐字保存在会话笔记文件，无损挺过上下文压缩。",
-    "en": "File-backed working memory: memorize/recall key premises verbatim in a session notes file so they survive context compaction losslessly."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:ICCuse/dsh-file-memory",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-knowledge",
-   "owner": "ICCuse",
-   "url": "https://github.com/ICCuse/dsh-knowledge",
-   "category": "memory",
-   "description": {
-    "zh": "全局知识库桥：kb_add/kb_search/kb_show/kb_timeline 读写与 Codex 共享的 D:\\knowledge（格式逐字节兼容）。",
-    "en": "Bridge into a global Markdown knowledge base shared with the Codex kb.cmd CLI: kb_add/kb_search/kb_show/kb_timeline tools with byte-compatible frontmatter."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:ICCuse/dsh-knowledge",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "kb-rag",
-   "owner": "Breeze136",
-   "url": "https://github.com/Breeze136/kb-rag",
-   "category": "memory",
-   "description": {
-    "zh": "本地文献知识库 RAG：8 个工具（PDF/文件夹/Zotero 入库、BM25+向量+重排混合检索、DOI 可点击溯源问答、范围/严格模式、去重/清空/统计），全本地 bge 嵌入 + 单文件 SQLite，实测 242 篇 86s 入库、2 万块亚秒热查询。",
-    "en": "Local literature knowledge-base RAG: 8 tools (PDF/folder/Zotero ingest, hybrid BM25+vector+reranker search, cited QA with clickable DOI links, scope/strict modes, dedup/clear/stats), all-local bge embeddings + single-file SQLite, measured 242-doc/86s ingest and sub-second hot queries on 20k chunks."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Breeze136/kb-rag",
-   "added": "2026-08-16"
-  },
-  {
-   "name": "dsh-premise-guard",
-   "owner": "ICCuse",
-   "url": "https://github.com/ICCuse/dsh-premise-guard",
-   "category": "memory",
-   "description": {
-    "zh": "压缩后前提漂移守卫：摘要丢失关键字面锚点时注入一次性提醒。",
-    "en": "Post-compaction premise-drift guard: injects a one-shot notice when a compaction summary drops a critical literal anchor."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:ICCuse/dsh-premise-guard",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "sgme",
-   "owner": "freehul",
-   "url": "https://github.com/freehul/sgme",
-   "category": "memory",
-   "description": {
-    "zh": "拾光记忆引擎（SGME）桥接：多智能体共享长期记忆（HTTP）—— L0/L1/L1.5/L2 分层提炼、按场景注入、统一检索、主动关怀信号（memory_search / wiki_search / signal_pull / signal_claim / signal_ack），npm 包名 `dsh-sgme`。",
-    "en": "ShiGuang Memory Engine (SGME) bridge: multi-agent shared long-term memory via HTTP — L0/L1/L1.5/L2 distillation, scenario-based injection, unified search, and proactive care signals (memory_search / wiki_search / signal_pull / signal_claim / signal_ack), installable as `dsh-sgme`."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:freehul/sgme",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-memory-meow",
-   "owner": "Phant0Meow",
-   "url": "https://github.com/Phant0Meow/dsh-memory-meow",
-   "category": "memory",
-   "description": {
-    "zh": "项目级跨会话记忆：PROJECT.md 快照注入首条用户消息（缓存友好）+ memory_remember 工具 + ReAct 任务结束自动反思；各项目独立记忆文件，互不互通。",
-    "en": "Project-scoped cross-session memory: PROJECT.md snapshot injected into the first user message, a memory_remember tool, and auto-reflection after ReAct tasks; each project keeps its own memory file."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Phant0Meow/dsh-memory-meow",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "billion-context-dsh",
-   "owner": "Tyan66666",
-   "url": "https://github.com/Tyan66666/billion-context-dsh",
-   "category": "memory",
-   "description": {
-    "zh": "模型驱动的上下文压缩：由模型决定何时压缩、压缩什么。",
-    "en": "Model-driven context compression: the model decides when and what to compress."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Tyan66666/billion-context-dsh",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-shared-memory",
-   "owner": "futongxu9-maker",
-   "url": "https://github.com/futongxu9-maker/dsh-shared-memory",
-   "category": "memory",
-   "description": {
-    "zh": "跨对话共享记忆：MEMORY.md + USER.md 注入每个会话系统提示词，memory 工具 + 可视化记忆面板，Hermes 式实现。",
-    "en": "Cross-conversation shared memory: MEMORY.md + USER.md injected into every session's system prompt, with a memory tool and a GUI panel (Hermes-style)."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:futongxu9-maker/dsh-shared-memory",
-   "added": "2026-08-16"
-  },
-  {
-   "name": "hkinsure",
-   "owner": "Anlushu",
-   "url": "https://github.com/Anlushu/hkinsure",
-   "category": "tools",
-   "description": {
-    "zh": "香港保险数据 MCP：260+ 真实产品、17 家保司、分红实现率，供 Hermes / dsh / Claude Code 等 AI 工具查询/对比/测算。",
-    "en": "Hong Kong insurance data MCP: 260+ real products, 17 insurers, dividend fulfillment rates. Query/compare/calculate for any AI tool (Hermes / dsh / Claude Code)."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Anlushu/hkinsure",
-   "added": "2026-08-16"
-  },
-  {
-   "name": "dsh-repo-setup",
-   "owner": "gongyijie85",
-   "url": "https://github.com/gongyijie85/dsh-repo-setup",
-   "category": "tools",
-   "description": {
-    "zh": "只读仓库体检引导工具（repo_setup_scan）：识别技术栈/测试/文档/git/数据库线索，给出技能插件、MCP 服务器与卫生文件的安装建议（claude-code-setup 的 DSH 对应）。",
-    "en": "Read-only repo bootstrap scanner (repo_setup_scan tool): detects stack/tests/docs/git/db hints and recommends skill plugins, MCP servers and hygiene files (claude-code-setup counterpart)."
-   },
-   "npm": "dsh-repo-setup",
-   "install": "dsh plugin --profile web add dsh-repo-setup",
-   "added": "2026-08-16"
-  },
-  {
-   "name": "dsh-tool-vision",
-   "owner": "gloryxpnv",
-   "url": "https://github.com/gloryxpnv/dsh-tool-vision",
-   "category": "tools",
-   "description": {
-    "zh": "为纯文本 DeepSeek Harness 提供本地优先视觉：由本地 VLM（LM Studio / Ollama / vLLM）产出结构化 JSON 证据（OCR / 版面 / 语义），零 API 成本，图片数据完全不出本机。",
-    "en": "Local-first vision for the text-only DeepSeek Harness: a local VLM (LM Studio / Ollama / vLLM) produces structured JSON evidence (OCR / layout / semantics) at zero API cost, with image data never leaving the machine."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:gloryxpnv/dsh-tool-vision",
-   "added": "2026-08-16"
-  },
-  {
-   "name": "dsh-plugin-net-access",
-   "owner": "Gumiho12345",
-   "url": "https://github.com/Gumiho12345/dsh-plugin-net-access",
-   "category": "tools",
-   "description": {
-    "zh": "DSH 的 net-access 权限模式：文件写保护不变，沙箱内 curl.exe 可用 HTTPS（Windows）。",
-    "en": "Net Access permission mode: keeps workspace-write protection while making curl.exe HTTPS work inside the sandbox (Windows)."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Gumiho12345/dsh-plugin-net-access",
-   "added": "2026-08-15"
-  },
-  {
-   "name": "coding-coach",
-   "owner": "xiehuan123",
-   "url": "https://github.com/xiehuan123/coding-coach",
-   "category": "tools",
-   "description": {
-    "zh": "Coding Coach 编程教练：面向非开发人员的 35 技能 bundle + 完整 Agent 预设（八段编排流水线 + 工程/产品/界面技能），npm 可装 `dsh plugin add coding-coach`，同时提供 Claude Code 插件。",
-    "en": "Coding Coach: a 35-skill bundle plus a full agent preset for non-developers (8-stage product→launch pipeline with engineering/product/UI skills), installable via npm (`dsh plugin add coding-coach`) and as a Claude Code plugin."
-   },
-   "npm": "coding-coach",
-   "install": "dsh plugin --profile web add coding-coach",
-   "added": "2026-08-15"
-  },
-  {
-   "name": "dsh-deepread",
-   "owner": "xiehuan123",
-   "url": "https://github.com/xiehuan123/dsh-deepread",
-   "category": "tools",
-   "description": {
-    "zh": "DeepRead 精读助手：五种精读模式（quick / deep / map 知识地图（四档置信度）/ feynman 费曼读书法 / book 全书）、批量对比、预算预检与后台任务进度透明、微信公众号链接 / .pdf 文件（内置纯 JS 提取器）/ 粘贴文本，可选导出 MD / FreeMind 思维导图（XMind 可导入）/ 编辑风网页报告。",
-    "en": "DeepRead: deep-reading assistant with five modes (quick / deep / knowledge map with four confidence levels / Feynman reading / whole book), batch comparison, budget preflight, and transparent background-job progress, from WeChat article links / local .pdf (built-in pure-JS extractor) / pasted text, with optional MD / FreeMind / styled HTML export."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:xiehuan123/dsh-deepread",
-   "added": "2026-08-15"
-  },
-  {
-   "name": "dsh-vision-router",
-   "owner": "ysr666",
-   "url": "https://github.com/ysr666/dsh-vision-router",
-   "category": "tools",
-   "description": {
-    "zh": "为纯文本 Agent 提供视觉能力：内置免 Key 视觉链 + 像素级视觉工具（看图问答、定位、裁剪、像素对比、取色、OCR、矢量化、抠图、截图）；粘贴图片即可用。",
-    "en": "Free vision for text-only agents: built-in keyless vision chain plus pixel tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots); paste an image to use it."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:ysr666/dsh-vision-router",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-undo-plugin",
-   "owner": "lire1131",
-   "url": "https://github.com/lire1131/dsh-undo-plugin",
-   "category": "tools",
-   "description": {
-    "zh": "DSH 撤销/回退系统：配置变更自动存档，一键撤销/恢复/回退到任意版本，支持 WebUI 与离线 CLI/GUI 工具（DSH 启动失败也能救）。",
-    "en": "Undo/redo & rollback system for DSH: every config change is auto-snapshotted; undo/redo/restore to any version from the WebUI or the offline CLI/GUI tools (works even when DSH fails to boot)."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:lire1131/dsh-undo-plugin",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-bash-terminal",
-   "owner": "MAXeaglet",
-   "url": "https://github.com/MAXeaglet/dsh-bash-terminal",
-   "category": "tools",
-   "description": {
-    "zh": "一个 shell 工具：Windows 上统一执行 PowerShell / Git Bash / WSL，外加交互式 PTY 终端，默认终端由用户在设置中选择。",
-    "en": "One shell tool for PowerShell / Git Bash / WSL on Windows plus an interactive PTY terminal; the default terminal is chosen by the user in DSH settings."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:MAXeaglet/dsh-bash-terminal",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-vision-toolkit",
-   "owner": "Anionex",
-   "url": "https://github.com/Anionex/dsh-vision-toolkit",
-   "category": "tools",
-   "description": {
-    "zh": "让纯文本模型更好地做视觉任务：带意图的图片问答、长截图 OCR、UI 还原等。",
-    "en": "Vision tasks for text-only models: intent-aware image Q&A, long-screenshot OCR, UI reproduction, grounding, and pixel diff."
-   },
-   "npm": "@dsh-external/dsh-vision-toolkit",
-   "install": "dsh plugin --profile web add @dsh-external/dsh-vision-toolkit",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-custom-tool",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/dsh-custom-tool",
-   "category": "tools",
-   "description": {
-    "zh": "用 Monaco 编辑器创建和管理沙箱化的自定义 JavaScript 工具。",
-    "en": "Create and manage sandboxed JavaScript tools with a Monaco editor and model-driven tool lifecycle."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/dsh-custom-tool",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-computer-use",
-   "owner": "Anionex",
-   "url": "https://github.com/Anionex/dsh-computer-use",
-   "category": "tools",
-   "description": {
-    "zh": "macOS 电脑控制：Accessibility 观测、过期状态拒绝、作用域权限与安全输入。",
-    "en": "Accessibility-first macOS computer use: fresh observations, stale-state rejection, scoped permissions, and safe input."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Anionex/dsh-computer-use",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-mobile-gui-agent",
-   "owner": "kunjinkao-os",
-   "url": "https://github.com/kunjinkao-os/dsh-mobile-gui-agent",
-   "category": "tools",
-   "description": {
-    "zh": "Android GUI Agent：ADB 截图、压缩 UI hierarchy 定位、逐步动作验证、审批和 Mobile Web 视图。",
-    "en": "Android GUI Agent with ADB screenshots, compact UI hierarchy grounding, verified iterative actions, approvals, and a Mobile Web view."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:kunjinkao-os/dsh-mobile-gui-agent",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-data-agent",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/dsh-data-agent",
-   "category": "tools",
-   "description": {
-    "zh": "让 AI 帮你连数据库、写 SQL。",
-    "en": "Let the AI connect to databases and write SQL for you."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/dsh-data-agent",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-toolkit",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/dsh-toolkit",
-   "category": "tools",
-   "description": {
-    "zh": "零依赖工具包：time / encoding / json / calculator / csv / regex / markdown / diff / stat / schema 十件套一键安装。",
-    "en": "Zero-dependency toolkit: time / encoding / json / calculator / csv / regex / markdown / diff / stat / schema — ten deterministic tools in one install."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/dsh-toolkit",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-remote",
-   "owner": "flymysql",
-   "url": "https://github.com/flymysql/dsh-remote",
-   "category": "tools",
-   "description": {
-    "zh": "远程工作区：SSH 密码或 key 连接远程主机，选取远程工作区目录，用 rw_pick_workspace / rw_list_dir / rw_read_file / rw_exec 工具在远程直接操作。",
-    "en": "Remote workspace: connect a host over SSH (password or key), pick a remote workspace directory and operate on it with rw_pick_workspace / rw_list_dir / rw_read_file / rw_exec tools."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:flymysql/dsh-remote",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-tool-csv",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/dsh-tool-csv",
-   "category": "tools",
-   "description": {
-    "zh": "CSV 解析/查询/统计/转换（RFC 4180），零依赖状态机解析器。",
-    "en": "Parse/query/aggregate/convert CSV (RFC 4180) with a zero-dependency state-machine parser."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-csv",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-tool-calculator",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/dsh-tool-calculator",
-   "category": "tools",
-   "description": {
-    "zh": "安全的数学表达式求值器，零依赖递归下降解析器。",
-    "en": "Safe math expression evaluator, zero-dependency recursive-descent parser."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-calculator",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-tool-diff",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/dsh-tool-diff",
-   "category": "tools",
-   "description": {
-    "zh": "文本/JSON/CSV/Markdown 结构化比较与 unified diff。",
-    "en": "Structured comparison and unified diffs for text/JSON/CSV/Markdown."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-diff",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-tool-encoding",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/dsh-tool-encoding",
-   "category": "tools",
-   "description": {
-    "zh": "base64/url/hex 编解码、常用哈希、UUID 生成。",
-    "en": "base64/url/hex encoding, common hashes, and UUID generation."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-encoding",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-tool-json",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/dsh-tool-json",
-   "category": "tools",
-   "description": {
-    "zh": "JMESPath 子集 JSON 查询。",
-    "en": "JSON queries with a JMESPath subset."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-json",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-tool-markdown",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/dsh-tool-markdown",
-   "category": "tools",
-   "description": {
-    "zh": "HTML↔Markdown 转换、GFM 表格规范化、目录生成。",
-    "en": "HTML↔Markdown conversion, GFM table normalization, and TOC generation."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-markdown",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-tool-regex",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/dsh-tool-regex",
-   "category": "tools",
-   "description": {
-    "zh": "正则测试/提取/安全替换/静态解释（不执行代码）。",
-    "en": "Test/extract/safe-replace/statically explain regexes without executing code."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-regex",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-tool-schema",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/dsh-tool-schema",
-   "category": "tools",
-   "description": {
-    "zh": "JSON Schema 验证：validate/paths/explain/normalize。",
-    "en": "JSON Schema validation: validate/paths/explain/normalize."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-schema",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-tool-stat",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/dsh-tool-stat",
-   "category": "tools",
-   "description": {
-    "zh": "描述统计/百分位数/频数分布/相关性。",
-    "en": "Descriptive statistics, percentiles, frequency distributions, and correlation."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-stat",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-tool-time",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/dsh-tool-time",
-   "category": "tools",
-   "description": {
-    "zh": "严格 ISO 8601 解析、IANA 时区转换、UTC 日历运算。",
-    "en": "Strict ISO 8601 parsing, IANA timezone conversion, and UTC calendar arithmetic."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-time",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-kb-sieve",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/dsh-kb-sieve",
-   "category": "tools",
-   "description": {
-    "zh": "从 md/txt/docx/pdf 构建可审计知识库包（SQLite FTS5），确定性检索与原文阅读。",
-    "en": "Build auditable KB packs (SQLite FTS5) from md/txt/docx/pdf with deterministic retrieval and original-text reading."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/dsh-kb-sieve",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-plugin-mineru",
-   "owner": "HuanLinOTO",
-   "url": "https://github.com/HuanLinOTO/dsh-plugin-mineru",
-   "category": "tools",
-   "description": {
-    "zh": "向模型暴露 MineRU 文档解析工具。",
-    "en": "Expose MineRU document parsing tools to the model."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:HuanLinOTO/dsh-plugin-mineru",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-plugin-anydoc",
-   "owner": "beancookie",
-   "url": "https://github.com/beancookie/dsh-plugin-anydoc",
-   "category": "tools",
-   "description": {
-    "zh": "将 @firecrawl/anydoc 作为 anydoc 工具注册给 Agent，把 Word/PPT/Excel/PDF/EPUB 等多种文档格式转换为 GitHub-Flavored Markdown。",
-    "en": "Registers @firecrawl/anydoc as an `anydoc` tool for the Agent, converting Word/PPT/Excel/PDF/EPUB and other document formats into GitHub-Flavored Markdown."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:beancookie/dsh-plugin-anydoc",
-   "added": "2026-08-15"
-  },
-  {
-   "name": "dsh-cowork",
-   "owner": "Jesse-njx",
-   "url": "https://github.com/Jesse-njx/dsh-cowork",
-   "category": "tools",
-   "description": {
-    "zh": "doc_read/doc_write：以有界、单元格寻址的方式读写 xlsx / pdf / docx / pptx / ipynb，另附 MCP 服务器与 CLI。",
-    "en": "Bounded, cell-addressed `doc_read`/`doc_write` for xlsx / pdf / docx / pptx / ipynb, plus an MCP server and CLI."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Jesse-njx/dsh-cowork",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-skillport",
-   "owner": "Jesse-njx",
-   "url": "https://github.com/Jesse-njx/dsh-skillport",
-   "category": "tools",
-   "description": {
-    "zh": "把已有的 Agent Skills（SKILL.md）技能库带进 DSH：扫描 Claude/Codex/Cursor/Gemini 技能目录、注入渐进式索引，按需加载技能正文。",
-    "en": "Bring your existing Agent Skills (SKILL.md) library to DSH: discover skills across Claude/Codex/Cursor/Gemini paths, inject a progressive-disclosure index, and load bodies on demand."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Jesse-njx/dsh-skillport",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "pack-agent",
-   "owner": "sakikoTGW",
-   "url": "https://github.com/sakikoTGW/pack-agent",
-   "category": "tools",
-   "description": {
-    "zh": "把 .pack.json/.pack.zip 投影到 .agent-pack/modpacks/，按工作区白名单暴露 skill。",
-    "en": "Project .pack.json/.pack.zip into .agent-pack/modpacks/ and expose skills via a workspace allow-list."
-   },
-   "npm": "@sakikotgw/pack-agent",
-   "install": "dsh plugin --profile web add @sakikotgw/pack-agent",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-tool-search",
-   "owner": "vibeinging",
-   "url": "https://github.com/vibeinging/dsh-tool-search",
-   "category": "tools",
-   "description": {
-    "zh": "按 agent 的按需工具发现与渐进式 schema 披露。",
-    "en": "Per-agent on-demand tool discovery and progressive schema disclosure."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:vibeinging/dsh-tool-search",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-openmaic",
-   "owner": "THU-MAIC",
-   "url": "https://github.com/THU-MAIC/dsh-openmaic",
-   "category": "tools",
-   "description": {
-    "zh": "OpenMAIC 教学：课堂、幻灯片、交互组件与苏格拉底式教学。",
-    "en": "OpenMAIC: classrooms, slides, interactive widgets, and Socratic teaching."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:THU-MAIC/dsh-openmaic",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-scholar",
-   "owner": "lzszq",
-   "url": "https://github.com/lzszq/dsh-scholar",
-   "category": "tools",
-   "description": {
-    "zh": "学术助手插件。",
-    "en": "Academic assistant plugin."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:lzszq/dsh-scholar",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "noatmark-dsh-plugin",
-   "owner": "ylwl1997",
-   "url": "https://github.com/ylwl1997/noatmark-dsh-plugin",
-   "category": "tools",
-   "description": {
-    "zh": "文本卫生 dsh 插件：净化不可信文本、扫描隐形字符、清洗 LLM 格式、转义 CSV 公式注入。",
-    "en": "Text hygiene as a dsh plugin: sanitize untrusted text, scan invisible characters, clean LLM formatting, and escape CSV formula injection."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:ylwl1997/noatmark-dsh-plugin",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-apple-mode",
-   "owner": "jihongboo",
-   "url": "https://github.com/jihongboo/dsh-apple-mode",
-   "category": "tools",
-   "description": {
-    "zh": "DSH 的 Xcode AI 集成：26 个 Xcode MCP 工具（mcpbridge）+ Apple 平台技能 + Xcode Intelligence 风格 persona（agent preset 或全局 bundle）。",
-    "en": "Xcode AI integration for DSH: 26 Xcode MCP tools (mcpbridge) + Apple platform skills + Xcode Intelligence-style persona (agent preset or global bundle)."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:jihongboo/dsh-apple-mode",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-continual-evolve",
-   "owner": "ZK-Andy",
-   "url": "https://github.com/ZK-Andy/dsh-continual-evolve",
-   "category": "tools",
-   "description": {
-    "zh": "持续自进化：从会话轨迹沉淀版本化、可审计、可回滚的 harness 状态（提示词/记忆/技能/子代理规格），带审查门禁与技能热加载。",
-    "en": "Continual self-evolution: versioned, auditable, rollback-safe harness state (prompts, memory, skills, subagent specs) refined from session trajectories, with review gates and hot-reloaded skills."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:ZK-Andy/dsh-continual-evolve",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-recommend",
-   "owner": "zp-home",
-   "url": "https://github.com/zp-home/dsh-recommend",
-   "category": "tools",
-   "description": {
-    "zh": "DSH 插件透明排行与推荐：每日自动抓取 `dsh-plugin` 话题生态，公开评分模型，提供 rank/search/recommend 工具与设置页榜单。",
-    "en": "Transparent rankings and recommendations for the DSH plugin ecosystem: daily auto-fetched topic data, an open scoring model, and rank/search/recommend tools with a settings-page leaderboard."
-   },
-   "npm": "dsh-recommend",
-   "install": "dsh plugin --profile web add dsh-recommend",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "modlens",
-   "owner": "liustack",
-   "url": "https://github.com/liustack/modlens",
-   "category": "tools",
-   "description": {
-    "zh": "为纯文本模型架起视觉桥梁：粘贴图片，输出结构化 JSON 证据（OCR、版面、语义）。",
-    "en": "Vision bridge for text-only models: paste an image, get structured JSON evidence (OCR, layout, semantics)."
-   },
-   "npm": "@liustack/modlens",
-   "install": "dsh plugin --profile web add @liustack/modlens",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-market",
-   "owner": "dsh-market",
-   "url": "https://github.com/dsh-market/dsh-market",
-   "category": "tools",
-   "description": {
-    "zh": "装在 DSH 里的插件市场：设置页内逛/搜全部社区插件，按分类筛选，确认后一键安装，已装插件一目了然。",
-    "en": "The plugin market inside DSH: a Settings page to browse and search the full community catalog by category, with confirmed one-click installs and an installed-plugins view."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:dsh-market/dsh-market",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-find-plugin",
-   "owner": "awesome-dsh-plugin",
-   "url": "https://github.com/awesome-dsh-plugin/dsh-find-plugin",
-   "category": "tools",
-   "description": {
-    "zh": "会话内直接找插件：按关键词/分类搜索本精选 registry，返回描述与可直接执行的安装命令。",
-    "en": "Find plugins without leaving the agent: search this curated registry by keyword or category, with ready-to-run install commands."
-   },
-   "npm": "dsh-find-plugin",
-   "install": "dsh plugin --profile web add dsh-find-plugin",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-code-intel",
-   "owner": "lonelymoon87",
-   "url": "https://github.com/lonelymoon87/dsh-code-intel",
-   "category": "tools",
-   "description": {
-    "zh": "用 Tree-sitter 建立工作区符号索引，提供词法或可选 embedding 辅助的代码检索。",
-    "en": "Indexes workspace symbols with Tree-sitter and provides lexical or optional embedding-assisted code search."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:lonelymoon87/dsh-code-intel",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-subagent-tools",
-   "owner": "lynx-gt",
-   "url": "https://github.com/lynx-gt/dsh-subagent-tools",
-   "category": "tools",
-   "description": {
-    "zh": "子代理委派的按调用覆盖：model/provider/persona/toolFilter、@preset: 引用与 provider/model 组合 id。",
-    "en": "Per-call model, provider, persona, and toolFilter overrides for subagent delegation, with @preset: references and provider/model composite ids."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:lynx-gt/dsh-subagent-tools",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-subagent-cwd",
-   "owner": "lynx-gt",
-   "url": "https://github.com/lynx-gt/dsh-subagent-cwd",
-   "category": "tools",
-   "description": {
-    "zh": "在 dsh-subagent-tools 基础上增加子代理按调用 cwd，附带所需的两个 in-process provider 补丁。",
-    "en": "Extends dsh-subagent-tools with a per-call cwd for subagents, shipped with the two in-process provider patches it requires."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:lynx-gt/dsh-subagent-cwd",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-voice",
-   "owner": "Jesse-njx",
-   "url": "https://github.com/Jesse-njx/dsh-voice",
-   "category": "tools",
-   "description": {
-    "zh": "语音输入、语音输出：把口述音频转写为用户消息（transcribe），让 agent 朗读回复（speak），本地优先，音频存于 ~/.dsh/voice。",
-    "en": "Voice notes in, spoken answers out: dictate audio that becomes user messages (transcribe), have the agent read replies aloud (speak), local-first under ~/.dsh/voice."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Jesse-njx/dsh-voice",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-voice-chat",
-   "owner": "lak321",
-   "url": "https://github.com/lak321/dsh-voice-chat",
-   "category": "tools",
-   "description": {
-    "zh": "语音对话：🎤 语音输入（Web Speech，实时中间结果可编辑）+ 🔊 自动/手动朗读回复（TTS），支持人声/语速/语调设置与识别语言（普通话/粤语等），纯客户端零密钥，朗读前自动清理 Markdown 标记。",
-    "en": "Voice chat: 🎤 speech input (Web Speech, live editable interim results) plus 🔊 automatic/manual read-aloud replies (TTS), with voice, speed, pitch and recognition-language settings (Mandarin/Cantonese, etc.); fully client-side with zero keys, and Markdown is stripped before reading."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:lak321/dsh-voice-chat",
-   "added": "2026-08-16"
-  },
-  {
-   "name": "dsh-screen-agent",
-   "owner": "lak321",
-   "url": "https://github.com/lak321/dsh-screen-agent",
-   "category": "tools",
-   "description": {
-    "zh": "桌面与网页自动化：📸 多屏截图 + 🔍 Windows OCR（文字+像素坐标）+ 🖱️ 鼠标点击/拖拽 + ⌨️ 中文打字/按键 + 🪟 窗口激活，含实战打磨的画图能力（鼠标加速度补偿、画布定位、贝塞尔曲线，可在画图中绘制图形）。",
-    "en": "Desktop and web automation: 📸 multi-screen screenshots, 🔍 Windows OCR (text + pixel coordinates), 🖱️ mouse click/drag, ⌨️ Chinese typing/keys, and 🪟 window activation, with battle-tested drawing in Paint (mouse acceleration compensation, canvas positioning, Bézier curves)."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:lak321/dsh-screen-agent",
-   "added": "2026-08-16"
-  },
-  {
-   "name": "dsh-docker",
-   "owner": "Jesse-njx",
-   "url": "https://github.com/Jesse-njx/dsh-docker",
-   "category": "tools",
-   "description": {
-    "zh": "类型安全、带护栏的容器控制：ps/logs/inspect/exec/start/stop 与 compose up/down，JSON 输出、项目感知定位、破坏性操作需审批。",
-    "en": "Typed, guarded container control: ps/logs/inspect/exec/start/stop and compose up/down with JSON output, project-aware targeting, and approval-gated destructive ops."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Jesse-njx/dsh-docker",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-excel-chat",
-   "owner": "hccccc01333",
-   "url": "https://github.com/hccccc01333/dsh-excel-chat",
-   "category": "tools",
-   "description": {
-    "zh": "在 DeepSeek Harness 里对话完成 Excel 工作：建表、编辑、修复公式、图表校验，每次编辑后自动体检公式。",
-    "en": "Talk to Excel in DeepSeek Harness: create, edit, repair, and verify spreadsheets by conversation, with automatic formula health checks after every edit."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:hccccc01333/dsh-excel-chat",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-context-proxy",
-   "owner": "EvilIrving",
-   "url": "https://github.com/EvilIrving/dsh-context-proxy",
-   "category": "tools",
-   "description": {
-    "zh": "按需取回薄层：context_query / context_slice / context_grep 三个工具读取已持久化的历史，引用可回放。",
-    "en": "Thin on-demand context retrieval: context_query / context_slice / context_grep tools that read already-persisted history back with replay-safe citations."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:EvilIrving/dsh-context-proxy",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "notes",
-   "owner": "zhaoolee",
-   "url": "https://github.com/zhaoolee/notes",
-   "category": "tools",
-   "description": {
-    "zh": "将 DSH 对话导出为锤子便签风格 PNG，或在配置的账号工作区中新建和更新 Markdown 便签。",
-    "en": "Export DSH conversations as Smartisan Notes-style PNGs, or create and update Markdown notes in a configured account-scoped workspace."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:zhaoolee/notes",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-figma-to-lottie",
-   "owner": "zimai233",
-   "url": "https://github.com/zimai233/dsh-figma-to-lottie",
-   "category": "tools",
-   "description": {
-    "zh": "将 SVG 路径与关键帧参数编译成自包含的 Lottie JSON 动画文件。",
-    "en": "Compile SVG paths and keyframe specs into self-contained Lottie JSON animation files."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:zimai233/dsh-figma-to-lottie",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-exam-countdown",
-   "owner": "zimai233",
-   "url": "https://github.com/zimai233/dsh-exam-countdown",
-   "category": "tools",
-   "description": {
-    "zh": "查询 64 场中国考试（高考/考研/四六级/CPA/法考…）的规则日期（第二个周六、第一个周日）与倒计时。",
-    "en": "Query 64 Chinese exams (高考/考研/四六级/CPA/法考…) with rule-aware date math (2nd-Saturday, 1st-Sunday) and countdowns."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:zimai233/dsh-exam-countdown",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-wash-calendar",
-   "owner": "zimai233",
-   "url": "https://github.com/zimai233/dsh-wash-calendar",
-   "category": "tools",
-   "description": {
-    "zh": "基于纯日期数学的周期习惯排程：下次发生日、区间排程与逾期提醒。",
-    "en": "Recurring-habit scheduling from pure date math: next occurrence, range schedules, and overdue advice."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:zimai233/dsh-wash-calendar",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-adhd-copilot",
-   "owner": "zimai233",
-   "url": "https://github.com/zimai233/dsh-adhd-copilot",
-   "category": "tools",
-   "description": {
-    "zh": "ADHD 行为辅导技能：任务拆解、事项过载管理、启动仪式与失败重启。",
-    "en": "ADHD behavioral coaching skill: task breakdown, overwhelm management, launch rituals, and failure recovery."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:zimai233/dsh-adhd-copilot",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-image-search",
-   "owner": "zimai233",
-   "url": "https://github.com/zimai233/dsh-image-search",
-   "category": "tools",
-   "description": {
-    "zh": "多引擎反向识图聚合：Google Lens、百度、Yandex、TinEye、SauceNAO、IQDB、Ascii2d。",
-    "en": "Multi-engine reverse image search aggregator: Google Lens, Baidu, Yandex, TinEye, SauceNAO, IQDB, Ascii2d."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:zimai233/dsh-image-search",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-video-downloader",
-   "owner": "zimai233",
-   "url": "https://github.com/zimai233/dsh-video-downloader",
-   "category": "tools",
-   "description": {
-    "zh": "检测并下载 B站/YouTube/抖音/小红书视频媒体，带清晰度与格式分析。",
-    "en": "Detect and download media from Bilibili/YouTube/Douyin/Xiaohongshu with quality and format analysis."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:zimai233/dsh-video-downloader",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-plugin-knowledge-graph",
-   "owner": "Luke-Yong",
-   "url": "https://github.com/Luke-Yong/dsh-plugin-knowledge-graph",
-   "category": "tools",
-   "description": {
-    "zh": "基于代码库知识图谱的 read_graph 工具（CONTAINS / EXPORTS / IMPORTS / IMPORTS_SYMBOL 关系）。",
-    "en": "A read_graph tool backed by a codebase knowledge graph (CONTAINS / EXPORTS / IMPORTS / IMPORTS_SYMBOL relations)."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Luke-Yong/dsh-plugin-knowledge-graph",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "modsearch",
-   "owner": "liustack",
-   "url": "https://github.com/liustack/modsearch",
-   "category": "tools",
-   "description": {
-    "zh": "纯文本 agent 的联网搜索桥：搜索网页与 X，返回结构化 JSON 证据（search/fetch/引用）。",
-    "en": "Web search bridge for text-only agents: ask the web or X, get structured JSON evidence (search, fetch, citations)."
-   },
-   "npm": "@liustack/modsearch",
-   "install": "dsh plugin --profile web add @liustack/modsearch",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "argo",
-   "owner": "taxueseek",
-   "url": "https://github.com/taxueseek/argo",
-   "category": "tools",
-   "description": {
-    "zh": "专为 agent 打造的搜索工具：多语言，覆盖中文/英文/学术/代码/购物/金融/新闻/百科。",
-    "en": "Search built for agents: multilingual coverage across web, academic, code, shopping, finance, news, and encyclopedias."
-   },
-   "npm": "argo-search",
-   "install": "dsh plugin --profile web add argo-search",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-web-search-exa",
-   "owner": "TonyDua",
-   "url": "https://github.com/TonyDua/dsh-web-search-exa",
-   "category": "tools",
-   "description": {
-    "zh": "ctx.web 接缝的零配置 Exa 网页搜索提供方：无 API key 时走匿名 MCP 兜底，配 key 时走 REST 搜索。",
-    "en": "Zero-config Exa web search provider for the ctx.web seam: anonymous MCP fallback without an API key, plus keyed REST search."
-   },
-   "npm": "@tonydua/dsh-web-search-exa",
-   "install": "dsh plugin --profile web add @tonydua/dsh-web-search-exa",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-browser",
-   "owner": "Lum1104",
-   "url": "https://github.com/Lum1104/dsh-browser",
-   "category": "tools",
-   "description": {
-    "zh": "Chrome 侧边栏扩展，让 DSH 直接操控你的浏览器，无需视觉能力。",
-    "en": "Chrome sidebar extension that lets DSH operate your browser directly, no vision capabilities required."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Lum1104/dsh-browser",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-webui-market-plugin",
-   "owner": "Sanqi-normal",
-   "url": "https://github.com/Sanqi-normal/dsh-webui-market-plugin",
-   "category": "tools",
-   "description": {
-    "zh": "dsh Web GUI 内的社区插件市场：浏览 awesome-dsh-plugin.com 目录，从 设置 → 插件 → 插件市场 安装/卸载插件到 profile。",
-    "en": "In-harness plugin market for the dsh web GUI: browse the awesome-dsh-plugin.com catalog and install/uninstall plugins into a profile from Settings → Plugins → Plugin Market."
-   },
-   "npm": "@sanqi-normal/dsh-webui-market-plugin",
-   "install": "dsh plugin --profile web add @sanqi-normal/dsh-webui-market-plugin",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "trio",
-   "owner": "huey1in",
-   "url": "https://github.com/huey1in/trio",
-   "category": "tools",
-   "description": {
-    "zh": "浏览器自动化（Playwright，带实时画面）+ MCP Server（把 DSH agent 暴露给任何 MCP 客户端）+ GitHub issue/PR/webhook 评审工具。",
-    "en": "Browser automation (Playwright) with a live view, an MCP server exposing DSH agents to any MCP client, and GitHub issue/PR/webhook review tools."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:huey1in/trio",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-adb",
-   "owner": "SamXiaBing",
-   "url": "https://github.com/SamXiaBing/dsh-adb",
-   "category": "tools",
-   "description": {
-    "zh": "ADB 设备·台架运维工具集：设备发现、结构化 logcat（后台采集）、apk 安装、文件 pull/push、性能快照。",
-    "en": "ADB device & bench operations for DSH: device discovery, structured logcat (background streaming), apk install, file pull/push, and dumpsys performance snapshots."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:SamXiaBing/dsh-adb",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-backup",
-   "owner": "xiaoyuyu6420",
-   "url": "https://github.com/xiaoyuyu6420/dsh-backup",
-   "category": "tools",
-   "description": {
-    "zh": "一键备份 DSH 用户数据：/backup 命令、定时自动备份、sha256 校验与自动轮换。",
-    "en": "One-command backup of DSH user data: /backup, scheduled auto-backup, sha256 checksums and rotation."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:xiaoyuyu6420/dsh-backup",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-hdc-bridge",
-   "owner": "1na-ko",
-   "url": "https://github.com/1na-ko/dsh-hdc-bridge",
-   "category": "tools",
-   "description": {
-    "zh": "鸿蒙设备桥：hdc 截图/装包/日志/崩溃/UI 自动化闭环（配 read_image 看图），官方优先版本化 API 知识层（SDK .d.ts + 离线随包文档），以及 DevEco CLI 构建/签名/lint 通道。",
-    "en": "HarmonyOS device bridge: hdc screenshot/install/log/crash/UI automation loop with read_image, official-first versioned API knowledge (SDK .d.ts + offline bundled docs), and a DevEco CLI build/sign/lint lane."
-   },
-   "npm": "dsh-hdc-bridge",
-   "install": "dsh plugin --profile web add dsh-hdc-bridge",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-plugin",
-   "owner": "PicGo",
-   "url": "https://github.com/PicGo/dsh-plugin",
-   "category": "tools",
-   "description": {
-    "zh": "通过 PicGo 已有配置（PicGo Cloud、GitHub、S3、腾讯云 COS、七牛，或任意已安装的上传插件）把本地图片和文件上传到图床，提供 `picgo_upload` 工具与 `/picgo` 命令。",
-    "en": "Upload local images and files to your image host through PicGo's existing configuration (PicGo Cloud, GitHub, S3, COS, Qiniu, or any installed uploader plugin), via a `picgo_upload` tool and a `/picgo` command."
-   },
-   "npm": "@picgo/dsh-plugin",
-   "install": "dsh plugin --profile web add @picgo/dsh-plugin",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-file-mount",
-   "owner": "acefun29",
-   "url": "https://github.com/acefun29/dsh-file-mount",
-   "category": "tools",
-   "description": {
-    "zh": "文件增量挂载与重复读取去重：已挂载行范围不重复进上下文。",
-    "en": "Incremental file mounting with read dedupe: mounted line ranges are never re-sent to the model."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:acefun29/dsh-file-mount",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-learn-everything",
-   "owner": "cendaifeng",
-   "url": "https://github.com/cendaifeng/dsh-learn-everything",
-   "category": "tools",
-   "description": {
-    "zh": "费曼学习法教学闭环，渲染为富 HTML 教学卡片。",
-    "en": "Feynman learning-mode loop rendered as rich HTML lesson cards."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:cendaifeng/dsh-learn-everything",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-news-plugin",
-   "owner": "canghai666x",
-   "url": "https://github.com/canghai666x/dsh-news-plugin",
-   "category": "tools",
-   "description": {
-    "zh": "RSS 新闻采集工具，抓取 10+ 中英文源为结构化条目。",
-    "en": "RSS news fetch tool that grabs 10+ CN/EN feeds into structured items."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:canghai666x/dsh-news-plugin",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-office",
-   "owner": "dsh-external",
-   "url": "https://github.com/dsh-external/dsh-office",
-   "category": "tools",
-   "description": {
-    "zh": "模型读写 Office 文件，web 客户端 docx/pdf 预览。",
-    "en": "Model reads/edits Office files with docx/pdf preview in the web client."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:dsh-external/dsh-office",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-browser-panel",
-   "owner": "dsh-external",
-   "url": "https://github.com/dsh-external/dsh-browser-panel",
-   "category": "tools",
-   "description": {
-    "zh": "WebUI 内嵌有头浏览器，模型实时操控、0 视觉依赖。",
-    "en": "Headed browser embedded in the WebUI, model-driven and zero vision deps."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:dsh-external/dsh-browser-panel",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "browser4-dsh",
-   "owner": "dsh-external",
-   "url": "https://github.com/dsh-external/browser4-dsh",
-   "category": "tools",
-   "description": {
-    "zh": "Browser4 AI-native 浏览器引擎（skills）。",
-    "en": "Browser4 AI-native browser engine exposed as skills."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:dsh-external/browser4-dsh",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-harness-mcp-server",
-   "owner": "chushixixin",
-   "url": "https://github.com/chushixixin/dsh-harness-mcp-server",
-   "category": "tools",
-   "description": {
-    "zh": "MCP server 让任意 MCP 客户端驱动 Harness agent。",
-    "en": "MCP server that lets any MCP client drive the Harness agent."
-   },
-   "npm": "@chushixixin/dsh-harness-mcp-server",
-   "install": "dsh plugin --profile web add @chushixixin/dsh-harness-mcp-server",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-tool-git",
-   "owner": "lxj808624",
-   "url": "https://github.com/lxj808624/dsh-tool-git",
-   "category": "tools",
-   "description": {
-    "zh": "结构化 Git 工具（status/diff/log/branch/stage/commit）+ 破坏性命令安全护栏。",
-    "en": "Structured Git tools (status/diff/log/branch/stage/commit) with a destructive-command guard."
-   },
-   "npm": "dsh-tool-git",
-   "install": "dsh plugin --profile web add dsh-tool-git",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-report-studio",
-   "owner": "ciceroyang",
-   "url": "https://github.com/ciceroyang/dsh-report-studio",
-   "category": "tools",
-   "description": {
-    "zh": "把 DSH 会话一键变成日报/周报/交接文档/文章，附可验证凭据。",
-    "en": "Turn a DSH session into daily/weekly/handoff/article reports with verifiable receipts."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:ciceroyang/dsh-report-studio",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-plugin-writing-guard",
-   "owner": "xmutfyh",
-   "url": "https://github.com/xmutfyh/dsh-plugin-writing-guard",
-   "category": "tools",
-   "description": {
-    "zh": "论文写作守卫：本地规则扫描修改过程残留、防御性写作与 AI 写作痕迹（破折号滥用、不是X而是Y、LLM 高频词、三连排比），论文文件写入后增量自动审计（writing_audit / writing_rules）。",
-    "en": "Academic writing guard: local-regex linter for revision-process residue, defensive writing and AI-writing tells (em-dash abuse, not-X-but-Y, LLM word spikes, rule of three), with incremental auto-audit on paper file writes (writing_audit + writing_rules)."
-   },
-   "npm": "dsh-plugin-writing-guard",
-   "install": "dsh plugin --profile web add dsh-plugin-writing-guard",
-   "added": "2026-08-15"
-  },
-  {
-   "name": "dsh-plugin-grok2api-media-tool",
-   "owner": "lsjspl",
-   "url": "https://github.com/lsjspl/dsh-plugin-grok2api-media-tool",
-   "category": "tools",
-   "description": {
-    "zh": "让 dsh 通过 grok2api 的 API 获得生成图片与视频能力。",
-    "en": "Gives dsh the ability to generate images and videos through the grok2api API."
-   },
-   "npm": "dsh-plugin-grok2api-media-tool",
-   "install": "dsh plugin --profile web add dsh-plugin-grok2api-media-tool",
-   "added": "2026-08-15"
-  },
-  {
-   "name": "dsh-path-reveal",
-   "owner": "futongxu9-maker",
-   "url": "https://github.com/futongxu9-maker/dsh-path-reveal",
-   "category": "tools",
-   "description": {
-    "zh": "点击消息里的 Windows 绝对路径在资源管理器中打开所在文件夹（文件定位选中/目录直接打开）。",
-    "en": "Click any absolute Windows path in DSH messages to reveal it in Explorer (select the file or open the folder)."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:futongxu9-maker/dsh-path-reveal",
-   "added": "2026-08-16"
-  },
-  {
-   "name": "dsh-sxs-anti-bot-http",
-   "owner": "yangyunsong023",
-   "url": "https://github.com/yangyunsong023/dsh-sxs-anti-bot-http",
-   "category": "tools",
-   "description": {
-    "zh": "反爬 HTTP 工具：UA 池轮换、指数退避重试、反爬墙检测（验证码/安全验证）与自适应限流，提炼自 SXS 生产采集体系（每日数百万请求）——工具：`sxs_fetch` / `sxs_fetch_json` / `sxs_rate_status`。",
-    "en": "Anti-bot HTTP fetch tools hardened by SXS's production scraping stack (millions of requests/day): UA-pool rotation, retry with exponential backoff, anti-bot wall detection (captcha / verification challenges) and adaptive rate limiting — tools: `sxs_fetch` / `sxs_fetch_json` / `sxs_rate_status`."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:yangyunsong023/dsh-sxs-anti-bot-http",
-   "added": "2026-08-16"
-  },
-  {
-   "name": "dsh-sxs-news-collector",
-   "owner": "yangyunsong023",
-   "url": "https://github.com/yangyunsong023/dsh-sxs-news-collector",
-   "category": "tools",
-   "description": {
-    "zh": "时事热点采集：一次调用聚合百度热搜 / 头条热榜 / 抖音热点 / 微博热搜（微博可选 cookie），返回标题+热度值，供内容创作借势——工具：`sxs_news_hot`。",
-    "en": "Trending-topics collector aggregating Baidu / Toutiao / Douyin / Weibo hot lists in one call (Weibo optional cookie), returning titles with heat values for content creators — tool: `sxs_news_hot`."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:yangyunsong023/dsh-sxs-news-collector",
-   "added": "2026-08-16"
-  },
-  {
-   "name": "dsh-llm-inspector",
-   "owner": "cdxiaodong",
-   "url": "https://github.com/cdxiaodong/dsh-llm-inspector",
-   "category": "tools",
-   "description": {
-    "zh": "统一 LLM 请求/响应检查器：调 reasoning effort、外部思考(think)导出、流量与包分析。",
-    "en": "Unified LLM request/response inspector: reasoning-effort tuning, external-think export, traffic & bundle analysis."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:cdxiaodong/dsh-llm-inspector",
-   "added": "2026-08-16"
-  },
-  {
-   "name": "dsh-ponytail",
-   "owner": "gongyijie85",
-   "url": "https://github.com/gongyijie85/dsh-ponytail",
-   "category": "skill",
-   "description": {
-    "zh": "最懒资深工程师模式（Ponytail）的 DSH 移植：6 个技能（ponytail、ponytail-audit、ponytail-debt、ponytail-gain、ponytail-help、ponytail-review），改编自 DietrichGebert/ponytail（MIT）。",
-    "en": "Ponytail, lazy senior dev mode, for DSH: 6 skills (ponytail, ponytail-audit, ponytail-debt, ponytail-gain, ponytail-help, ponytail-review) adapted from DietrichGebert/ponytail (MIT)."
-   },
-   "npm": "dsh-ponytail-skills",
-   "install": "dsh plugin --profile web add dsh-ponytail-skills",
-   "added": "2026-08-16"
-  },
-  {
-   "name": "skills",
-   "owner": "creght-dev",
-   "url": "https://github.com/creght-dev/skills",
-   "category": "skill",
-   "description": {
-    "zh": "Creght 平台建站技能包：CLI 拉取/推送同步、页面与组件规范、CMS、表单、Auth、SEO、发布与版本回滚。",
-    "en": "Skills for building websites on the Creght platform: CLI pull/push sync, page and component conventions, CMS, forms, auth, SEO, publishing and version rollback."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:creght-dev/skills",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "Code2Skill",
-   "owner": "leechen298",
-   "url": "https://github.com/leechen298/Code2Skill",
-   "category": "skill",
-   "description": {
-    "zh": "从现有代码生成 Function、MCP、Agent Skill 和离线测试包，并作为可安装的 DSH Bundle 分发。",
-    "en": "Generates Function, MCP, Agent Skill, and offline test packages from existing code as an installable DSH bundle."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:leechen298/Code2Skill",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-reverse-skill",
-   "owner": "dhicoc",
-   "url": "https://github.com/dhicoc/dsh-reverse-skill",
-   "category": "skill",
-   "description": {
-    "zh": "完整 reverse-skill 技能包（85 个 SKILL.md）的 DeepSeek Harness 插件：面向逆向工程、授权渗透测试与安全研究的技能路由包。",
-    "en": "Complete reverse-skill pack (85 SKILL.md files) as a DeepSeek Harness plugin: a skill router for reverse engineering, authorized penetration testing, and security research."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:dhicoc/dsh-reverse-skill",
-   "added": "2026-08-15"
-  },
-  {
-   "name": "mattpocock-skills-dsh",
-   "owner": "gongyijie85",
-   "url": "https://github.com/gongyijie85/mattpocock-skills-dsh",
-   "category": "skill",
-   "description": {
-    "zh": "Matt Pocock 完整发布技能集（25 个 SKILL.md：grilling、writing-for-agents、wait-what、TDD、code-review、wayfinder、ask-matt 路由等）的 DeepSeek Harness 插件：改编自 mattpocock/skills（MIT）。",
-    "en": "Matt Pocock's full promoted skill set (25 SKILL.md files: grilling, writing-for-agents, wait-what, TDD, code-review, wayfinder, ask-matt router and more) as a DeepSeek Harness plugin, adapted from mattpocock/skills (MIT)."
-   },
-   "npm": "mattpocock-skills-dsh",
-   "install": "dsh plugin --profile web add mattpocock-skills-dsh",
-   "added": "2026-08-16"
-  },
-  {
-   "name": "mattpocock-skills-dsh-zh",
-   "owner": "gongyijie85",
-   "url": "https://github.com/gongyijie85/mattpocock-skills-dsh-zh",
-   "category": "skill",
-   "description": {
-    "zh": "Matt Pocock 技能中文版的 DeepSeek Harness 插件：25 个 SKILL.md 正文全译中文（技术术语保留英文并附注释），改编自 mattpocock/skills（MIT）。",
-    "en": "Matt Pocock's skills in Chinese for DSH: all 25 SKILL.md translated to natural Chinese (technical terms kept in English with glosses), adapted from mattpocock/skills (MIT)."
-   },
-   "npm": "mattpocock-skills-dsh-zh",
-   "install": "dsh plugin --profile web add mattpocock-skills-dsh-zh",
-   "added": "2026-08-16"
-  },
-  {
-   "name": "dsh-usage-billing",
-   "owner": "940842546",
-   "url": "https://github.com/940842546/dsh-usage-billing",
-   "category": "workflow",
-   "description": {
-    "zh": "用量与消费统计：8/17 调价前后峰谷计费，主界面汇总面板、按会话明细与用量热力图。",
-    "en": "Usage and cost statistics with peak/off-peak pricing after the 2026-08-17 rate change, a floating summary panel, per-session breakdowns, and a usage heatmap."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:940842546/dsh-usage-billing",
-   "added": "2026-08-15"
-  },
-  {
-   "name": "dsh_workflow",
-   "owner": "icetomoyo",
-   "url": "https://github.com/icetomoyo/dsh_workflow",
-   "category": "workflow",
-   "description": {
-    "zh": "把 UltraCode 式多 Agent 调度带给 DSH：可生成、可保存、可治理、可观察、可恢复的 Workflow 层。",
-    "en": "UltraCode-style multi-agent orchestration: a generatable, savable, governable, observable, resumable workflow layer."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:icetomoyo/dsh_workflow",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-agent-teams",
-   "owner": "NanmiCoder",
-   "url": "https://github.com/NanmiCoder/dsh-agent-teams",
-   "category": "workflow",
-   "description": {
-    "zh": "AgentTeams 多智能体团队。",
-    "en": "AgentTeams multi-agent teams."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:NanmiCoder/dsh-agent-teams",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-automation",
-   "owner": "titanwings",
-   "url": "https://github.com/titanwings/dsh-automation",
-   "category": "workflow",
-   "description": {
-    "zh": "定时任务：让 Coding 任务按计划在全新 Agent Session 中运行，保留可审计历史。",
-    "en": "Scheduled coding runs in fresh agent sessions with auditable history."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:titanwings/dsh-automation",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-plugin-automations",
-   "owner": "Sev7een",
-   "url": "https://github.com/Sev7een/dsh-plugin-automations",
-   "category": "workflow",
-   "description": {
-    "zh": "设置页定时任务：支持准点或 DeepSeek 谷时段执行、单次/每日重复，并持久化任务状态。",
-    "en": "Settings-based scheduled tasks that run on time or during DeepSeek off-peak hours, with one-time and daily schedules backed by durable task state."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Sev7een/dsh-plugin-automations",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-routines",
-   "owner": "Jesse-njx",
-   "url": "https://github.com/Jesse-njx/dsh-routines",
-   "category": "workflow",
-   "description": {
-    "zh": "定时 Agent：按 cron 计划运行 prompt，把摘要送到你已有的地方，内置重叠/漏跑/超时安全策略。",
-    "en": "Scheduled agents on a cron: run a prompt on a schedule and get the digest where you already are, with overlap/missed-run/timeout safety defaults."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Jesse-njx/dsh-routines",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-plannotator",
-   "owner": "titanwings",
-   "url": "https://github.com/titanwings/dsh-plannotator",
-   "category": "workflow",
-   "description": {
-    "zh": "计划批注：选中计划原文逐条批注，结构化反馈送回 Agent。",
-    "en": "Plan review with anchored annotations and structured feedback back to the agent."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:titanwings/dsh-plannotator",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-loop",
-   "owner": "vlln",
-   "url": "https://github.com/vlln/dsh-loop",
-   "category": "workflow",
-   "description": {
-    "zh": "定时循环：`/loop` 命令 + loop 工具 + 活动状态条。",
-    "en": "Recurring loops: `/loop` command + loop tool + activity status bar."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:vlln/dsh-loop",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-sentinel",
-   "owner": "fuhefei",
-   "url": "https://github.com/fuhefei/dsh-sentinel",
-   "category": "workflow",
-   "description": {
-    "zh": "条件驱动唤醒：file/command/http/process/webhook 持久监视，触发即唤醒 agent。",
-    "en": "Condition-driven wakeup: durable file/command/http/process/webhook watches that wake the agent."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:fuhefei/dsh-sentinel",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-deep-research",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/dsh-deep-research",
-   "category": "workflow",
-   "description": {
-    "zh": "自适应深度研究编排器（基于官方 workflow 引擎）。",
-    "en": "Adaptive deep-research orchestrator built on the official workflow engine."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/dsh-deep-research",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-inspect",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/dsh-inspect",
-   "category": "workflow",
-   "description": {
-    "zh": "发现问题→修复交付→质量复查的对抗式闭环工具集。",
-    "en": "Adversarial checkup → fix → review loop toolset."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/dsh-inspect",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-track",
-   "owner": "fakechris",
-   "url": "https://github.com/fakechris/dsh-track",
-   "category": "workflow",
-   "description": {
-    "zh": "嵌入式任务管理引擎：决策点协议、念头捕获墙、Linear 形 issue 存储。",
-    "en": "Embedded task management engine: decision-point protocol, idea capture wall, Linear-style issue store."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:fakechris/dsh-track",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-advisor",
-   "owner": "btspoony",
-   "url": "https://github.com/btspoony/dsh-advisor",
-   "category": "workflow",
-   "description": {
-    "zh": "搭配一个副模型，每轮被动审查并注入见解。",
-    "en": "Pair a second model that passively reviews each turn and injects notes."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:btspoony/dsh-advisor",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-specflow",
-   "owner": "lonelymoon87",
-   "url": "https://github.com/lonelymoon87/dsh-specflow",
-   "category": "workflow",
-   "description": {
-    "zh": "增加规格工件、技能、命令、由 goal 驱动的实施流程和任务进度上下文。",
-    "en": "Adds specification artifacts, skills, commands, goal-backed implementation, and task-progress context."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:lonelymoon87/dsh-specflow",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-science",
-   "owner": "biociao",
-   "url": "https://github.com/biociao/dsh-science",
-   "category": "workflow",
-   "description": {
-    "zh": "面向 DSH 的 Claude Science 式科研工作台：ReAct 研究循环引擎（research_* 工具）、带溯源的版本化工件（artifact_* 工具）与面向基因组/病原体/生物信息的 10 个科研技能。",
-    "en": "Claude Science-style research workbench: ReAct research-loop engine (research_* tools), versioned artifacts with provenance (artifact_* tools), and 10 science skills for genomics/pathogens/bioinformatics."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:biociao/dsh-science",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-proof",
-   "owner": "EvilIrving",
-   "url": "https://github.com/EvilIrving/dsh-proof",
-   "category": "workflow",
-   "description": {
-    "zh": "独立只读验收层：顶层 turn 收尾前 spawn 只读 verifier，未通过时把缺口注回主 agent。",
-    "en": "Independent read-only acceptance layer: spawns a read-only verifier before each top-level turn closes and steers non-pass gaps back into the agent."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:EvilIrving/dsh-proof",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-doublecheck",
-   "owner": "PerryLink",
-   "url": "https://github.com/PerryLink/dsh-doublecheck",
-   "category": "workflow",
-   "description": {
-    "zh": "工程纪律守门：动笔前审讯需求，红绿测试证据门，交付后对抗评审（grill-requirements 技能 + 工具策略门）。",
-    "en": "Engineering-discipline guard: grill the requirements before the first edit, enforce red/green test evidence gates, and audit the delivery with a forked adversary (grill-requirements skill + tool-policy gates)."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:PerryLink/dsh-doublecheck",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "mstar-harness",
-   "owner": "btspoony",
-   "url": "https://github.com/btspoony/mstar-harness",
-   "category": "workflow",
-   "description": {
-    "zh": "技能驱动的 harness/loop 工程化工作流插件。",
-    "en": "Skill-driven harness/loop engineering workflow agent plugin."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:btspoony/mstar-harness",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-approval-llm",
-   "owner": "Letter2025",
-   "url": "https://github.com/Letter2025/dsh-approval-llm",
-   "category": "workflow",
-   "description": {
-    "zh": "基于模型的权限审批：由独立审查模型自动应答 approval 权限请求。",
-    "en": "Model-based permission approval: an approval-request answerer backed by a separate reviewer model."
-   },
-   "npm": "dsh-approval-llm",
-   "install": "dsh plugin --profile web add dsh-approval-llm",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-permissions",
-   "owner": "940842546",
-   "url": "https://github.com/940842546/dsh-permissions",
-   "category": "workflow",
-   "description": {
-    "zh": "Claude Code 风格权限规则引擎：hard/deny/ask/allow 四级规则（hard 高于全访问、不可豁免）、workspace 作用域、通配符路径保护、可视化草稿式编辑器，规则持久化于 settings.yaml。",
-    "en": "Claude Code-style permission rules engine: hard/deny/ask/allow tiers with a hard tier above full access, workspace-scoped rules, wildcard path protection, and a visual staged editor; rules persist in settings.yaml."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:940842546/dsh-permissions",
-   "added": "2026-08-16"
-  },
-  {
-   "name": "dsh-model-failover",
-   "owner": "Letter2025",
-   "url": "https://github.com/Letter2025/dsh-model-failover",
-   "category": "workflow",
-   "description": {
-    "zh": "两级模型熔断与回退：模型或平台连续失败后自动熔断，并把下一个请求路由到配置好的备用模型。",
-    "en": "Two-level model circuit breaker with failover: trip a model or a whole provider after repeated request failures and route the next request to a configured fallback."
-   },
-   "npm": "dsh-model-failover",
-   "install": "dsh plugin --profile web add dsh-model-failover",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-plan-execute",
-   "owner": "dsh-external",
-   "url": "https://github.com/dsh-external/dsh-plan-execute",
-   "category": "workflow",
-   "description": {
-    "zh": "plan/execute 双模型路由：规划模型思考、执行模型干活。",
-    "en": "Dual-model plan/execute routing: a planner model thinks, an executor model acts."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:dsh-external/dsh-plan-execute",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-open-in-vscode",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/dsh-open-in-vscode",
-   "category": "notify",
-   "description": {
-    "zh": "从 Web GUI 一键在 VS Code 中打开工作区目录。",
-    "en": "Open DSH workspace directories in VS Code directly from the web GUI."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/dsh-open-in-vscode",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-notification",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/dsh-notification",
-   "category": "notify",
-   "description": {
-    "zh": "回合完成桌面通知，按结果分控 + 关键词过滤。",
-    "en": "Desktop notifications for turn completions, with per-outcome controls and keyword rules."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/dsh-notification",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-acp-for-bitfun",
-   "owner": "bobleer",
-   "url": "https://github.com/bobleer/dsh-acp-for-bitfun",
-   "category": "notify",
-   "description": {
-    "zh": "BitFun 与 DSH 的 ACP 交互对接。",
-    "en": "ACP bridge between BitFun and DSH."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:bobleer/dsh-acp-for-bitfun",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "deepseek-harness-acp",
-   "owner": "openma-ai",
-   "url": "https://github.com/openma-ai/deepseek-harness-acp",
-   "category": "notify",
-   "description": {
-    "zh": "ACP profile 插件与独立 stdio server，可从 Zed 等 ACP 客户端使用完整 DSH agent，并共享 DSH 凭据与会话。",
-    "en": "ACP profile plugin and standalone stdio server for using the full DSH agent from Zed and other ACP clients while sharing DSH credentials and sessions."
-   },
-   "npm": "@openma/deepseek-harness-acp",
-   "install": "dsh plugin --profile web add @openma/deepseek-harness-acp",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "telegram",
-   "owner": "LoserFox",
-   "url": "https://github.com/LoserFox/telegram",
-   "category": "notify",
-   "description": {
-    "zh": "Telegram Bot API 桥接：长轮询、per-chat 会话、HTML 格式化。",
-    "en": "Bridge to the Telegram Bot API: long polling, per-chat sessions, HTML formatting."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:LoserFox/telegram",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-chatnode-wechat",
-   "owner": "Jesse-njx",
-   "url": "https://github.com/Jesse-njx/dsh-chatnode-wechat",
-   "category": "notify",
-   "description": {
-    "zh": "通过 iLink 网关在微信里与 DSH agent 聊天、监控与审批：双向文本、会话切换、进度摘要与编号审批提示。",
-    "en": "Chat with, monitor, and approve your DSH agents from WeChat via the iLink gateway: text both ways, session targeting, digest heartbeats, and numbered approval prompts."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Jesse-njx/dsh-chatnode-wechat",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-session-notification",
-   "owner": "dingyi222666",
-   "url": "https://github.com/dingyi222666/dsh-session-notification",
-   "category": "notify",
-   "description": {
-    "zh": "会话完成等四种状态的通知响应，支持浏览器提示。",
-    "en": "Notifications for four session states, with browser alerts and prompts."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:dingyi222666/dsh-session-notification",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-web-ui-notify",
-   "owner": "bill9109",
-   "url": "https://github.com/bill9109/dsh-web-ui-notify",
-   "category": "notify",
-   "description": {
-    "zh": "桌面通知提醒。",
-    "en": "Desktop notification reminders."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:bill9109/dsh-web-ui-notify",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-webbridge",
-   "owner": "bill9109",
-   "url": "https://github.com/bill9109/dsh-webbridge",
-   "category": "notify",
-   "description": {
-    "zh": "DSH 结合 Kimi WebBridge。",
-    "en": "DSH meets Kimi WebBridge."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:bill9109/dsh-webbridge",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-im-bridge",
-   "owner": "BiBoyang",
-   "url": "https://github.com/BiBoyang/dsh-im-bridge",
-   "category": "notify",
-   "description": {
-    "zh": "微信（iLink）双向桥：turn 完成/批准请求推送、聊天内批准与消息注入、持久去重与长回复收敛分段；通道层为多 IM 预留。",
-    "en": "Two-way WeChat (iLink) bridge: turn-end and approval-request push, in-chat approve/reject and message injection, persistent dedup and convergent long-reply chunking; channel layer extensible to other IMs."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:BiBoyang/dsh-im-bridge",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-lark-bridge",
-   "owner": "imetn",
-   "url": "https://github.com/imetn/dsh-lark-bridge",
-   "category": "notify",
-   "description": {
-    "zh": "DeepSeek Harness 的飞书/Lark 双向控制器，支持 Project 与 Session 路由、交互卡片、审批、附件和任务控制。",
-    "en": "Bidirectional Lark/Feishu controller for DeepSeek Harness with project and session routing, interactive cards, approvals, attachments, and task controls."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:imetn/dsh-lark-bridge",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-feishu-notify",
-   "owner": "dsh-external",
-   "url": "https://github.com/dsh-external/dsh-feishu-notify",
-   "category": "notify",
-   "description": {
-    "zh": "飞书通知（会话结束/等待输入）。",
-    "en": "Feishu notifications on session end / input needed."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:dsh-external/dsh-feishu-notify",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-notify-windows",
-   "owner": "SeverusZh",
-   "url": "https://github.com/SeverusZh/dsh-notify-windows",
-   "category": "notify",
-   "description": {
-    "zh": "Windows 通知，零依赖。",
-    "en": "Windows notifications, zero dependencies."
-   },
-   "npm": "dsh-notify-windows",
-   "install": "dsh plugin --profile web add dsh-notify-windows",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-notify-win",
-   "owner": "Andyqwe44",
-   "url": "https://github.com/Andyqwe44/dsh-notify-win",
-   "category": "notify",
-   "description": {
-    "zh": "原生 Windows toast + 任务栏闪烁，任务完成/审批/提问时触发，支持 Win10/11，npm 安装 `dsh plugin --profile web add dsh-notify-win`。",
-    "en": "Native Windows toast + taskbar flash for task done / approval / ask_user_question, Win10/11, npm install `dsh plugin --profile web add dsh-notify-win`."
-   },
-   "npm": "dsh-notify-win",
-   "install": "dsh plugin --profile web add dsh-notify-win",
-   "added": "2026-08-16"
-  },
-  {
-   "name": "dsh-opencode-server",
-   "owner": "dsh-external",
-   "url": "https://github.com/dsh-external/dsh-opencode-server",
-   "category": "notify",
-   "description": {
-    "zh": "通过 opencode attach 获得丝滑 TUI。",
-    "en": "Smooth TUI via opencode attach."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:dsh-external/dsh-opencode-server",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-island",
-   "owner": "cdxiaodong",
-   "url": "https://github.com/cdxiaodong/dsh-island",
-   "category": "notify",
-   "description": {
-    "zh": "通过 Unix socket 把 DSH agent 的会话、工具调用与审批实时桥接到 CodeIsland macOS 刘海面板，可直接在面板上批准/拒绝。",
-    "en": "Bridge DSH agent sessions, tool calls, and approvals to the CodeIsland macOS notch panel over a Unix socket, with in-panel allow/deny."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:cdxiaodong/dsh-island",
-   "added": "2026-08-16"
-  },
-  {
-   "name": "dsh-bell-notify",
-   "owner": "Laplace-bit",
-   "url": "https://github.com/Laplace-bit/dsh-bell-notify",
-   "category": "notify",
-   "description": {
-    "zh": "生命周期铃声与状态点：为每个环节合成专属提示音（Web Audio，零音频文件），右下角呼吸状态点显示工作状态。",
-    "en": "Lifecycle bells and a status dot: per-event chimes synthesized live with Web Audio (zero audio files), plus a breathing indicator for agent state."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Laplace-bit/dsh-bell-notify",
-   "added": "2026-08-16"
-  },
-  {
-   "name": "llm-adaptive",
-   "owner": "dylan121322",
-   "url": "https://github.com/dylan121322/llm-adaptive",
-   "category": "model",
-   "description": {
-    "zh": "自适应模型路由：请求级复杂度分类，按配置链自动选择后端 provider。",
-    "en": "Adaptive model routing: per-request complexity classification with automatic provider routing."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:dylan121322/llm-adaptive",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-llm-fallbacks",
-   "owner": "btspoony",
-   "url": "https://github.com/btspoony/dsh-llm-fallbacks",
-   "category": "model",
-   "description": {
-    "zh": "基于角色的模型重试与备用策略。",
-    "en": "Role-based LLM retry & fallback strategies."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:btspoony/dsh-llm-fallbacks",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-codex-connect",
-   "owner": "franksong2702",
-   "url": "https://github.com/franksong2702/dsh-codex-connect",
-   "category": "model",
-   "description": {
-    "zh": "通过 ChatGPT OAuth 将 OpenAI Codex 模型接入 DeepSeek Harness，并提供可选的搜索与图片工具。",
-    "en": "Connect ChatGPT OAuth and OpenAI Codex models to DeepSeek Harness, with opt-in search and image tools."
-   },
-   "npm": "dsh-codex-connect",
-   "install": "dsh plugin --profile web add dsh-codex-connect",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-everything-oauth",
-   "owner": "kam74515-boop",
-   "url": "https://github.com/kam74515-boop/dsh-everything-oauth",
-   "category": "model",
-   "description": {
-    "zh": "把本机 Codex / Grok / Claude / OpenCode / CC Switch 登录态导入 DSH，在设置里自选来源并启用模型。",
-    "en": "Import local Codex, Grok, Claude, OpenCode, and CC Switch logins into DSH; pick sources and enable models in Settings."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:kam74515-boop/dsh-everything-oauth",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "Qwen-MM-Plugins",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/Qwen-MM-Plugins",
-   "category": "model",
-   "description": {
-    "zh": "Qwen 多模态插件支持。",
-    "en": "Qwen multi-modal plugin support."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/Qwen-MM-Plugins",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-codex-auth",
-   "owner": "suntianc",
-   "url": "https://github.com/suntianc/dsh-codex-auth",
-   "category": "model",
-   "description": {
-    "zh": "复用 Codex CLI 的 ChatGPT 登录态注册 `openai-codex` LLM 路由，并在 DSH Web 设置中提供 GPT Auth 控件。",
-    "en": "Reuses the Codex CLI ChatGPT login as an `openai-codex` LLM route and adds GPT Auth controls to DSH Web settings."
-   },
-   "npm": "dsh-codex-auth",
-   "install": "dsh plugin --profile web add dsh-codex-auth",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-vision",
-   "owner": "dsh-external",
-   "url": "https://github.com/dsh-external/dsh-vision",
-   "category": "model",
-   "description": {
-    "zh": "视觉桥接：view_image 工具接任意 OpenAI 兼容 VLM。",
-    "en": "Vision bridge: view_image tool over any OpenAI-compatible VLM."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:dsh-external/dsh-vision",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "fabric",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/fabric",
-   "category": "dev",
-   "description": {
-    "zh": "类似 MC Fabric 的 hook 处理器。",
-    "en": "An MC-Fabric-style hook processor."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/fabric",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-harmony",
-   "owner": "CH4ACKO3",
-   "url": "https://github.com/CH4ACKO3/dsh-harmony",
-   "category": "dev",
-   "description": {
-    "zh": "让一个 DSH 插件在运行时修改另一个插件的代码，并提供 Patch 排序、冲突检查和热重载。",
-    "en": "Lets one DSH plugin modify another plugin's code at runtime, with Patch ordering, conflict checks, and hot reload."
-   },
-   "npm": "dsh-harmony",
-   "install": "dsh plugin --profile web add dsh-harmony",
-   "added": "2026-08-15"
-  },
-  {
-   "name": "dsh-git-identity",
-   "owner": "LoserFox",
-   "url": "https://github.com/LoserFox/dsh-git-identity",
-   "category": "dev",
-   "description": {
-    "zh": "git 提交固定使用环境自身作者身份，环境变量注入压过一切 `git config` 设置。",
-    "en": "Pin Git commits to the environment's own author identity; env-var injection overrides all `git config` settings."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:LoserFox/dsh-git-identity",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-context-doctor",
-   "owner": "Zhenyu98",
-   "url": "https://github.com/Zhenyu98/dsh-context-doctor",
-   "category": "dev",
-   "description": {
-    "zh": "上下文注入审计：统计指令链/技能目录/工具 schema 的 token 成本，检测重复与冲突。",
-    "en": "Context injection audit: token costs of instruction chains / skill catalogs / tool schemas, duplicate and conflict detection."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Zhenyu98/dsh-context-doctor",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-plugin-check",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/dsh-plugin-check",
-   "category": "dev",
-   "description": {
-    "zh": "插件健康检查：扫描清单协议/patch 格式/构建陷阱，零依赖只读。",
-    "en": "Plugin health checks: manifest protocol / patch format / build traps, zero-dependency and read-only."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/dsh-plugin-check",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-security-audit",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/dsh-security-audit",
-   "category": "dev",
-   "description": {
-    "zh": "本机安全审计：配置/插件来源/会话/网络暴露面，只读脱敏风险报告。",
-    "en": "Local security audit: config, plugin origins, sessions, network exposure — read-only redacted risk report."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/dsh-security-audit",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-session-health",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/dsh-session-health",
-   "category": "dev",
-   "description": {
-    "zh": "会话文件帧级扫描诊断（torn/损坏/空会话检测）。",
-    "en": "Frame-level scan diagnostics for session files (torn/corrupt/empty detection)."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/dsh-session-health",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-evolve",
-   "owner": "william-jin-cmu",
-   "url": "https://github.com/william-jin-cmu/dsh-evolve",
-   "category": "dev",
-   "description": {
-    "zh": "自进化：agent 在会话内给自己热挂载/卸载持久化插件。",
-    "en": "Self-evolution: the agent hot-mounts/removes persistent plugins on itself mid-session."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:william-jin-cmu/dsh-evolve",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-trace",
-   "owner": "vibeinging",
-   "url": "https://github.com/vibeinging/dsh-trace",
-   "category": "dev",
-   "description": {
-    "zh": "遥测后端：把 turns、model steps、tool calls 导出到 yiTrace。",
-    "en": "Telemetry backend exporting turns, model steps, and tool calls to yiTrace."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:vibeinging/dsh-trace",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-telemetry-redactor",
-   "owner": "030611",
-   "url": "https://github.com/030611/dsh-telemetry-redactor",
-   "category": "dev",
-   "description": {
-    "zh": "在已配置遥测后端接收前，对 `session-telemetry/record` 导出副本中的已支持秘密模式进行脱敏。",
-    "en": "Redacts supported secret patterns from the `session-telemetry/record` export copy before configured telemetry backends receive it."
-   },
-   "npm": "dsh-telemetry-redactor",
-   "install": "dsh plugin --profile web add dsh-telemetry-redactor",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-verification-receipt",
-   "owner": "030611",
-   "url": "https://github.com/030611/dsh-verification-receipt",
-   "category": "dev",
-   "description": {
-    "zh": "把每轮工具计数与粗粒度验证信号写入本地 JSONL，不保存提示词、工具参数或结果正文。",
-    "en": "Writes local JSONL summaries of per-turn tool counts and coarse verification signals without storing prompts, tool arguments, or result text."
-   },
-   "npm": "dsh-verification-receipt",
-   "install": "dsh plugin --profile web add dsh-verification-receipt",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "sandbox-micro",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/sandbox-micro",
-   "category": "dev",
-   "description": {
-    "zh": "microsandbox 沙箱支持。",
-    "en": "Support for the microsandbox backend."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/sandbox-micro",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "sandbox-mxc",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/sandbox-mxc",
-   "category": "dev",
-   "description": {
-    "zh": "微软跨平台沙盒支持。",
-    "en": "Microsoft cross-platform sandbox support."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/sandbox-mxc",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "sandbox-nono",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/sandbox-nono",
-   "category": "dev",
-   "description": {
-    "zh": "nono 沙盒支持。",
-    "en": "Support for the nono sandbox backend."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/sandbox-nono",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-agent-budget",
-   "owner": "vibeinging",
-   "url": "https://github.com/vibeinging/dsh-agent-budget",
-   "category": "dev",
-   "description": {
-    "zh": "agent 树 token 预算管理。",
-    "en": "Agent-tree token budget management."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:vibeinging/dsh-agent-budget",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-polyglot",
-   "owner": "Jesse-njx",
-   "url": "https://github.com/Jesse-njx/dsh-polyglot",
-   "category": "dev",
-   "description": {
-    "zh": "DSH 的模型切换器：指向任意 OpenAI 兼容端点，内置精选免费/低价 DeepSeek 服务商预设，免费额度限流时自动回退。",
-    "en": "The model switch for DSH: point it at any OpenAI-compatible endpoint, with curated free/cheap DeepSeek provider presets and automatic fallback when a free tier rate-limits you."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Jesse-njx/dsh-polyglot",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-tool-approval",
-   "owner": "ilharp",
-   "url": "https://github.com/ilharp/dsh-tool-approval",
-   "category": "dev",
-   "description": {
-    "zh": "手动审批模式（Manual/Ask Mode）。",
-    "en": "Manual approval mode (\"Manual Mode\" / \"Ask Mode\")."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:ilharp/dsh-tool-approval",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-turn-approval",
-   "owner": "arrow949",
-   "url": "https://github.com/arrow949/dsh-turn-approval",
-   "category": "dev",
-   "description": {
-    "zh": "DSH「允许本次任务」临时授权：仅在当前任务内自动放行同类 `danger-full-access` 请求，任务结束自动失效。",
-    "en": "Turn-scoped “Allow for this task” approvals: automatically allow matching `danger-full-access` escalations only for the current task, then expire."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:arrow949/dsh-turn-approval",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "plugin-template",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/plugin-template",
-   "category": "dev",
-   "description": {
-    "zh": "插件模板仓库（基于 turtle-ui 官方仓库）。",
-    "en": "Plugin template repo (based on the official turtle-ui repo)."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/plugin-template",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-tps",
-   "owner": "Small-tailqwq",
-   "url": "https://github.com/Small-tailqwq/dsh-tps",
-   "category": "dev",
-   "description": {
-    "zh": "TPS 指标插件。",
-    "en": "A TPS metrics plugin."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Small-tailqwq/dsh-tps",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-tool-call-stats",
-   "owner": "disyli",
-   "url": "https://github.com/disyli/dsh-tool-call-stats",
-   "category": "dev",
-   "description": {
-    "zh": "进程内工具调用统计：提供 `tool_stats` 工具，按工具汇报调用次数、失败次数与平均耗时。",
-    "en": "Per-process tool-call statistics: a `tool_stats` tool reporting per-tool call counts, error counts, and average durations."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:disyli/dsh-tool-call-stats",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-fail-logger",
-   "owner": "Areium",
-   "url": "https://github.com/Areium/dsh-fail-logger",
-   "category": "dev",
-   "description": {
-    "zh": "全模式调用工具失败自动实录：把原生工具 / PTC run_code / 代码内嵌工具调用的失败错因去重计数后写入 skill，越用越少错。",
-    "en": "Auto-log failed tool calls across native tools, PTC run_code, and inline invocations: dedup and count root causes into a skill so repeated mistakes fade."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Areium/dsh-fail-logger",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-eval-harness",
-   "owner": "BiBoyang",
-   "url": "https://github.com/BiBoyang/dsh-eval-harness",
-   "category": "dev",
-   "description": {
-    "zh": "DSH 插件评测框架：YAML 用例驱动真实 headless agent，断言工具调用/参数/返回与 token 用量，baseline 门禁做 CI 回归。",
-    "en": "Evaluation harness for DSH plugins: YAML cases drive real headless agent runs, assert on tool calls, args, results and token usage, with a baseline gate for CI regression."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:BiBoyang/dsh-eval-harness",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "oh-dsh",
-   "owner": "hust-open-atom-club",
-   "url": "https://github.com/hust-open-atom-club/oh-dsh",
-   "category": "dev",
-   "description": {
-    "zh": "社区发行版：TUI、桌面端与 Web UI 统一体验，分层安装、一步到位。",
-    "en": "Community distribution: TUI, desktop, and Web UI as one bundle with layered installation."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:hust-open-atom-club/oh-dsh",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-annotate",
-   "owner": "BrambleXu",
-   "url": "https://github.com/BrambleXu/dsh-annotate",
-   "category": "dev",
-   "description": {
-    "zh": "面向 Vibe Coding 的浏览器元素标注插件：直接选取页面元素，并将结构化视觉反馈发送给 DeepSeek Harness Agent。",
-    "en": "Select browser elements directly during Vibe Coding and send structured visual feedback to the DeepSeek Harness Agent."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:BrambleXu/dsh-annotate",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-prompt-profile",
-   "owner": "BrambleXu",
-   "url": "https://github.com/BrambleXu/dsh-prompt-profile",
-   "category": "dev",
-   "description": {
-    "zh": "DeepSeek Harness 可复用 Markdown Prompt Profile，支持单轮模型选择、参数替换和状态恢复。",
-    "en": "Reusable Markdown prompt profiles for DeepSeek Harness with per-turn model selection, argument substitution, and state restoration."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:BrambleXu/dsh-prompt-profile",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-revdiff",
-   "owner": "BrambleXu",
-   "url": "https://github.com/BrambleXu/dsh-revdiff",
-   "category": "dev",
-   "description": {
-    "zh": "DeepSeek Harness 原生交互式 Git diff 审查，支持结构化批注并回传当前 Agent 会话。",
-    "en": "Native interactive Git diff review for DeepSeek Harness with structured annotations sent back to the current Agent session."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:BrambleXu/dsh-revdiff",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-gitflow",
-   "owner": "lonelymoon87",
-   "url": "https://github.com/lonelymoon87/dsh-gitflow",
-   "category": "dev",
-   "description": {
-    "zh": "增加需要审批的 Git 状态、diff、日志、提交、分支和可选检查点工具。",
-    "en": "Adds approval-gated Git status, diff, log, commit, branch, and optional checkpoint tools."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:lonelymoon87/dsh-gitflow",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-guardian",
-   "owner": "lonelymoon87",
-   "url": "https://github.com/lonelymoon87/dsh-guardian",
-   "category": "dev",
-   "description": {
-    "zh": "增加危险操作策略检查、输出脱敏和安全审查工作流。",
-    "en": "Adds dangerous-operation policy checks, output redaction, and a security-review workflow."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:lonelymoon87/dsh-guardian",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-plugin-manager",
-   "owner": "Jesse-njx",
-   "url": "https://github.com/Jesse-njx/dsh-plugin-manager",
-   "category": "dev",
-   "description": {
-    "zh": "`dsh pm` 插件管理器：多源搜索（awesome 列表 + GitHub + npm）、按 profile 安装/移除/更新，以及 doctor 审计（清单、bundle patch、版本漂移）。",
-    "en": "The `dsh pm` plugin manager: multi-source search (awesome list + GitHub + npm), install/remove/update per profile, and a doctor audit of manifests, bundle patches, and version drift."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Jesse-njx/dsh-plugin-manager",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-tmuxctl",
-   "owner": "Jesse-njx",
-   "url": "https://github.com/Jesse-njx/dsh-tmuxctl",
-   "category": "dev",
-   "description": {
-    "zh": "掌控你的 tmux 面板：list/send-keys/capture、在面板中运行长任务并 watch，破坏性命令需审批。",
-    "en": "Take control of your tmux panes: list/send-keys/capture, run long jobs in a pane with watch mode, and approval-gated destructive commands."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Jesse-njx/dsh-tmuxctl",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-updater-ui",
-   "owner": "xingyingyuzhui",
-   "url": "https://github.com/xingyingyuzhui/dsh-updater-ui",
-   "category": "dev",
-   "description": {
-    "zh": "设置页中的 DSH 自助更新器：一键检查/拉取（git pull --ff-only）、自动后台检查、版本对比与更新说明预览，带红点提醒。",
-    "en": "DSH self-updater in the settings page: one-click check/pull (`git pull --ff-only`), auto background checks, version diff and changelog preview with a red-dot reminder."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:xingyingyuzhui/dsh-updater-ui",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-repro",
-   "owner": "EvilIrving",
-   "url": "https://github.com/EvilIrving/dsh-repro",
-   "category": "dev",
-   "description": {
-    "zh": "/repro 导出最小可复现问题包：去 secret 的会话日志、失败命令与 git diff。",
-    "en": "/repro exports a minimal, secret-scrubbed, replayable problem bundle: the session log, failed commands, and Git diff."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:EvilIrving/dsh-repro",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-mcp-panel",
-   "owner": "PerryLink",
-   "url": "https://github.com/PerryLink/dsh-mcp-panel",
-   "category": "dev",
-   "description": {
-    "zh": "官方 MCP 客户端（dsh-mcp-client）的只读运行时管理面板：/mcp 命令与设置页 MCP 页签展示连接状态、已注册工具、错误与重连计数，脱敏展示并提供启停 patch 建议。",
-    "en": "Read-only runtime management panel for the official DSH MCP client: connection status, registered tools, errors, and reconnect counts through the /mcp command and a Settings tab, with sanitized display and enable/disable patch suggestions."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:PerryLink/dsh-mcp-panel",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-pain-point-check",
-   "owner": "ICCuse",
-   "url": "https://github.com/ICCuse/dsh-pain-point-check",
-   "category": "dev",
-   "description": {
-    "zh": "强制痛点检查：同一问题连续 2 个实验未收敛后注入三问、拦截非调查类工具调用直到答出、阻止同方向重试。",
-    "en": "Enforced pain-point gate: after two non-converged experiments it injects the three questions, denies non-investigative tool calls until answered, and blocks same-direction retries."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:ICCuse/dsh-pain-point-check",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "forkprobe",
-   "owner": "Jayden-X-L",
-   "url": "https://github.com/Jayden-X-L/forkprobe",
-   "category": "dev",
-   "description": {
-    "zh": "同一任务并行试跑多个技能，对比结果选出最优。",
-    "en": "Compare multiple skills on the same task and pick the winner."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Jayden-X-L/forkprobe",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "plugin-registry",
-   "owner": "vlln",
-   "url": "https://github.com/vlln/plugin-registry",
-   "category": "dev",
-   "description": {
-    "zh": "插件生态基建：浏览器面板管理官方 repository 插件（0 patch）+ make-dsh-plugin 插件开发引导技能。",
-    "en": "Ecosystem infrastructure: a thin browser console for managing official repository plugins (zero patches) plus a make-dsh-plugin skill for guided plugin development."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:vlln/plugin-registry",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-multica-runtime",
-   "owner": "forrestchang",
-   "url": "https://github.com/forrestchang/dsh-multica-runtime",
-   "category": "dev",
-   "description": {
-    "zh": "让 dsh 运行时跑在 Multica 上。",
-    "en": "Run the dsh runtime on Multica."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:forrestchang/dsh-multica-runtime",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-user-experience",
-   "owner": "DietCokewithSugar",
-   "url": "https://github.com/DietCokewithSugar/dsh-user-experience",
-   "category": "dev",
-   "description": {
-    "zh": "帮你发现项目中可能存在的用户体验问题：自动走查 React/TypeScript 源码，定位问题并给出具体优化建议。",
-    "en": "Finds potential UX issues in your project: automatically reviews React/TypeScript code, pinpoints each problem, and gives concrete suggestions."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:DietCokewithSugar/dsh-user-experience",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-cost-tracker",
-   "owner": "yflmq001",
-   "url": "https://github.com/yflmq001/dsh-cost-tracker",
-   "category": "dev",
-   "description": {
-    "zh": "按模型追踪 token 成本：可配置缓存命中/未命中、输出与高峰时段单价，实时会话花费条，并标记未配置价格的模型。",
-    "en": "Per-model token cost tracking with configurable cache-hit/miss, output and peak-window pricing, a live session cost bar, and unconfigured-model flags."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:yflmq001/dsh-cost-tracker",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-passwords",
-   "owner": "slywalker2006",
-   "url": "https://github.com/slywalker2006/dsh-passwords",
-   "category": "dev",
-   "description": {
-    "zh": "DSH Web UI 登录网关：首次配置、bcrypt + 静态加密（AES-256-GCM/HMAC）、防爆破、审计日志、TLS 1.2+ 与 80→443 跳转、CSRF 与防嵌框。",
-    "en": "Login gateway for the DSH web UI: password door with first-run setup, bcrypt + at-rest encryption (AES-256-GCM/HMAC), brute-force lockout, audit log, TLS 1.2+ with 80→443 redirect, CSRF, anti-framing."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:slywalker2006/dsh-passwords",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-webui-auth",
-   "owner": "Yuuz12",
-   "url": "https://github.com/Yuuz12/dsh-webui-auth",
-   "category": "dev",
-   "description": {
-    "zh": "WebUI 身份认证：HTTP/传输层强制登录（资源、插件 bundle、/api、WebSocket 四层防护），服务端会话 + HttpOnly Cookie。",
-    "en": "WebUI authentication enforced at the HTTP/transport layer: four-layer login gate (resources, plugin bundles, /api, WebSocket), server-side sessions with HttpOnly cookies."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Yuuz12/dsh-webui-auth",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-lan-access",
-   "owner": "Leon0555",
-   "url": "https://github.com/Leon0555/dsh-lan-access",
-   "category": "dev",
-   "description": {
-    "zh": "局域网访问：Web GUI 绑定 0.0.0.0 + crypto.randomUUID polyfill（修复非安全上下文下 RPC 崩溃）。",
-    "en": "LAN access for the Web GUI: 0.0.0.0 bind plus a crypto.randomUUID polyfill for non-secure (LAN HTTP) contexts."
-   },
-   "npm": "dsh-lan-access",
-   "install": "dsh plugin --profile web add dsh-lan-access",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh4vscode",
-   "owner": "DoggyHU",
-   "url": "https://github.com/DoggyHU/dsh4vscode",
-   "category": "dev",
-   "description": {
-    "zh": "基于 DSH agent 的 VS Code 聊天窗口，模型自动路由。",
-    "en": "VS Code chat windows backed by the DSH agent with model auto-routing."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:DoggyHU/dsh4vscode",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-desktop",
-   "owner": "foolgry",
-   "url": "https://github.com/foolgry/dsh-desktop",
-   "category": "dev",
-   "description": {
-    "zh": "开箱即用的 Electron 桌面版，自动跟随上游发版。",
-    "en": "Download-and-run Electron desktop build that tracks upstream releases automatically."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:foolgry/dsh-desktop",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "deepseek-harness-action",
-   "owner": "Lixiaoyiao",
-   "url": "https://github.com/Lixiaoyiao/deepseek-harness-action",
-   "category": "dev",
-   "description": {
-    "zh": "GitHub Action 运行 DSH 做 PR 审查、CI 诊断与受信任修复。",
-    "en": "GitHub Action running DSH for PR review, CI diagnosis and trusted fixes."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Lixiaoyiao/deepseek-harness-action",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-test-runner",
-   "owner": "suimi8",
-   "url": "https://github.com/suimi8/dsh-test-runner",
-   "category": "dev",
-   "description": {
-    "zh": "结构化测试运行工具：自动识别 Vitest/Jest/pytest/node:test 并解析失败。",
-    "en": "Structured test runner tool: auto-detects Vitest/Jest/pytest/node:test and parses failures."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:suimi8/dsh-test-runner",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-review-loop",
-   "owner": "wuxiangru915",
-   "url": "https://github.com/wuxiangru915/dsh-review-loop",
-   "category": "dev",
-   "description": {
-    "zh": "增量 diff 审查器：Web 审查面板 + 审查意见注入 agent。",
-    "en": "Incremental diff reviewer with a Web UI panel and feedback injection into the agent."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:wuxiangru915/dsh-review-loop",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-mcp-manager",
-   "owner": "hyqhyq3",
-   "url": "https://github.com/hyqhyq3/dsh-mcp-manager",
-   "category": "dev",
-   "description": {
-    "zh": "MCP 服务器管理器：OAuth 或静态 token 认证 + 设置页。",
-    "en": "MCP server manager with OAuth or static-token auth and a Settings page."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:hyqhyq3/dsh-mcp-manager",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-doctor",
-   "owner": "asdf17128",
-   "url": "https://github.com/asdf17128/dsh-doctor",
-   "category": "dev",
-   "description": {
-    "zh": "Profile 体检：检出 patch 丢失字段、不存在的 entry id 与工具重名冲突。",
-    "en": "Profile health check: finds config fields dropped by patch, missing entry ids, and tool-name collisions."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:asdf17128/dsh-doctor",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-plugin-manager-registry",
-   "owner": "Jesse-njx",
-   "url": "https://github.com/Jesse-njx/dsh-plugin-manager-registry",
-   "category": "dev",
-   "description": {
-    "zh": "离线容错的插件注册表，聚合并去重各类来源的 DSH 插件。",
-    "en": "Offline-tolerant registry that discovers and deduplicates DSH plugins from lists, topics and npm."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Jesse-njx/dsh-plugin-manager-registry",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-session-cleaner",
-   "owner": "fountunt",
-   "url": "https://github.com/fountunt/dsh-session-cleaner",
-   "category": "dev",
-   "description": {
-    "zh": "无需重启即可删除运行中 Web 运行时里的会话。",
-    "en": "Delete sessions from a running web runtime without a restart."
-   },
-   "npm": "dsh-session-cleaner",
-   "install": "dsh plugin --profile web add dsh-session-cleaner",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-portable-launcher",
-   "owner": "15828148",
-   "url": "https://github.com/15828148/dsh-portable-launcher",
-   "category": "dev",
-   "description": {
-    "zh": "Windows 一键便携启动器，国内镜像回退。",
-    "en": "One-click portable Windows launcher with CN mirror fallback."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:15828148/dsh-portable-launcher",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-guardian",
-   "owner": "cdxiaodong",
-   "url": "https://github.com/cdxiaodong/dsh-guardian",
-   "category": "dev",
-   "description": {
-    "zh": "Agent 安全护栏：拦截并审计所有工具调用，命中敏感操作就要求人工确认。",
-    "en": "Agent security guardrail: intercepts and audits every tool call, requiring human confirmation on sensitive operations."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:cdxiaodong/dsh-guardian",
-   "added": "2026-08-16"
-  },
-  {
-   "name": "dsh-ads",
-   "owner": "Nagi-ovo",
-   "url": "https://github.com/Nagi-ovo/dsh-ads",
-   "category": "fun",
-   "description": {
-    "zh": "2005 年中文站点风格的整活广告插件：侧栏广告/信息流/角落弹窗 + 假关闭叉，素材全虚构。",
-    "en": "Parody ads in 2005-Chinese-web style: sidebar banners, in-chat feeds, corner popups, and a close button whose hit area is smaller than it looks. All fictional."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Nagi-ovo/dsh-ads",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-gomoku",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/dsh-gomoku",
-   "category": "fun",
-   "description": {
-    "zh": "与 AI 下五子棋，也可让 AI 对局比棋力。",
-    "en": "Play Gomoku against the AI, or let two AIs battle it out."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/dsh-gomoku",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-stock-market",
-   "owner": "AnacondaKC",
-   "url": "https://github.com/AnacondaKC/dsh-stock-market",
-   "category": "fun",
-   "description": {
-    "zh": "有效解决了写代码的时候账户不能同时亏钱的 BUG。",
-    "en": "Fixes the bug where your account can't lose money while you code."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:AnacondaKC/dsh-stock-market",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-emoji",
-   "owner": "hellodigua",
-   "url": "https://github.com/hellodigua/dsh-emoji",
-   "category": "fun",
-   "description": {
-    "zh": "为 AI 回复自动添加表情。",
-    "en": "Automatically add emojis to AI replies."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:hellodigua/dsh-emoji",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-minigames",
-   "owner": "lhh010",
-   "url": "https://github.com/lhh010/dsh-minigames",
-   "category": "fun",
-   "description": {
-    "zh": "右侧小游戏面板：18 款离线小游戏，等模型回复时的摸鱼神器。",
-    "en": "Side-panel arcade: 18 offline mini-games to play while the model thinks."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:lhh010/dsh-minigames",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-stickers",
-   "owner": "william-jin-cmu",
-   "url": "https://github.com/william-jin-cmu/dsh-stickers",
-   "category": "fun",
-   "description": {
-    "zh": "用户与 agent 双向表情贴纸互动。",
-    "en": "Bidirectional sticker reactions between user and agent."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:william-jin-cmu/dsh-stickers",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "whale-girl",
-   "owner": "vlln",
-   "url": "https://github.com/vlln/whale-girl",
-   "category": "fun",
-   "description": {
-    "zh": "桌面宠物（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍。",
-    "en": "Desktop pet (QQ-pet style): floats in the corner, draggable, feedable, playable."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:vlln/whale-girl",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "deepseek-manners",
-   "owner": "Moeblack",
-   "url": "https://github.com/Moeblack/deepseek-manners",
-   "category": "fun",
-   "description": {
-    "zh": "给每次消息后注入感谢语，做个有礼貌的人。",
-    "en": "Append a thank-you note after every message. Mind your manners."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:Moeblack/deepseek-manners",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-plugin-d399",
-   "owner": "HuanLinOTO",
-   "url": "https://github.com/HuanLinOTO/dsh-plugin-d399",
-   "category": "fun",
-   "description": {
-    "zh": "模型生成时弹出小游戏菜单（wordle/消消乐，可扩展）。",
-    "en": "Pops up a mini-game menu (wordle, match-3, extensible) while the model generates."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:HuanLinOTO/dsh-plugin-d399",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-auto-chess",
-   "owner": "omdsh-dev",
-   "url": "https://github.com/omdsh-dev/dsh-auto-chess",
-   "category": "fun",
-   "description": {
-    "zh": "自走棋：人机对战或双 AI 对弈。",
-    "en": "Auto chess: human vs AI, or AI vs AI."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:omdsh-dev/dsh-auto-chess",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "dsh-douyin",
-   "owner": "AnacondaKC",
-   "url": "https://github.com/AnacondaKC/dsh-douyin",
-   "category": "fun",
-   "description": {
-    "zh": "侧栏短视频：原生播放器、系列导航、精确历史回放。",
-    "en": "Short-video sidebar: native player, series navigation, precise history replay."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:AnacondaKC/dsh-douyin",
-   "added": "2026-08-13"
-  },
-  {
-   "name": "DeepSeek-Harness-Pet",
-   "owner": "minybear",
-   "url": "https://github.com/minybear/DeepSeek-Harness-Pet",
-   "category": "fun",
-   "description": {
-    "zh": "Codex 风格桌面宠物：右下角悬浮动画精灵，随 agent 运行状态实时变化（工作、等待、报错、完成）。",
-    "en": "Codex-style desktop pet: a floating animated sprite in the corner that mirrors the agent's running state (working, waiting, failed, done)."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:minybear/DeepSeek-Harness-Pet",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-web-search-pro",
-   "owner": "anweat",
-   "url": "https://github.com/anweat/dsh-web-search-pro",
-   "category": "fun",
-   "description": {
-    "zh": "增强型、可持久化的网页搜索：多引擎路由（DeepSeek/Exa/DDG/Bing/Jina + GitHub/B站/YouTube/V2EX/小红书/Twitter/Reddit/RSS）、SQLite+LRU 缓存、userscript 风格抽取、Playwright 渲染。",
-    "en": "Persistent enhanced web search: multi-engine routing (DeepSeek/Exa/DDG/Bing/Jina + GitHub/Bilibili/YouTube/V2EX/Xiaohongshu/Twitter/Reddit/RSS), SQLite+LRU cache, userscript-style extraction, Playwright rendering."
-   },
-   "npm": "dsh-web-search-pro",
-   "install": "dsh plugin --profile web add dsh-web-search-pro",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-browser",
-   "owner": "anweat",
-   "url": "https://github.com/anweat/dsh-browser",
-   "category": "fun",
-   "description": {
-    "zh": "自包含浏览器运行时：Playwright（chromium）+ OpenCLI 作为插件本地依赖（全局复用回退），提供 `browser` 服务与 9 个交互式浏览器工具。",
-    "en": "Self-contained browser runtime: Playwright (chromium) + OpenCLI as plugin-local dependencies (global reuse fallback), exposes a `browser` service and 9 interactive browser tools."
-   },
-   "npm": "@anweat/dsh-browser",
-   "install": "dsh plugin --profile web add @anweat/dsh-browser",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-voice-webspeech",
-   "owner": "anweat",
-   "url": "https://github.com/anweat/dsh-voice-webspeech",
-   "category": "fun",
-   "description": {
-    "zh": "浏览器 Web Speech API 语音输入：零服务端、零密钥、零模型下载（Edge=Azure 语音、Chrome=Google 语音）。",
-    "en": "Browser Web Speech API voice input: zero server, zero keys, zero model downloads (Edge=Azure, Chrome=Google speech)."
-   },
-   "npm": "dsh-voice-webspeech",
-   "install": "dsh plugin --profile web add dsh-voice-webspeech",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-restart",
-   "owner": "anweat",
-   "url": "https://github.com/anweat/dsh-restart",
-   "category": "fun",
-   "description": {
-    "zh": "DSH 重启插件：可配置的重启方式（Node 原生/旧 PowerShell 适配）、重启后自动继续的提示词、可选看门狗自动拉起。",
-    "en": "Restart DSH: configurable restart method (Node native / legacy PowerShell), post-restart continue prompt, optional watchdog auto-relaunch."
-   },
-   "npm": "dsh-restart",
-   "install": "dsh plugin --profile web add dsh-restart",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-pet",
-   "owner": "FlytoMAYDAY80",
-   "url": "https://github.com/FlytoMAYDAY80/dsh-pet",
-   "category": "fun",
-   "description": {
-    "zh": "桌面小鲸鱼，实时感知会话状态。",
-    "en": "Desktop whale pet with live session state."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:FlytoMAYDAY80/dsh-pet",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-weather",
-   "owner": "sunshine-lang",
-   "url": "https://github.com/sunshine-lang/dsh-weather",
-   "category": "fun",
-   "description": {
-    "zh": "天气工具：Open-Meteo 数据（免费，无需 API key）。",
-    "en": "Weather tool via Open-Meteo (free, no API key)."
-   },
-   "npm": "dsh-weather",
-   "install": "dsh plugin --profile web add dsh-weather",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-pdf",
-   "owner": "sunshine-lang",
-   "url": "https://github.com/sunshine-lang/dsh-pdf",
-   "category": "fun",
-   "description": {
-    "zh": "PDF 工具箱：基于 pdfjs-dist 提取文本、元数据与页码范围。",
-    "en": "PDF toolbox: extract text, metadata and page ranges via pdfjs-dist."
-   },
-   "npm": "dsh-pdf",
-   "install": "dsh plugin --profile web add dsh-pdf",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-ui-whale",
-   "owner": "dsh-external",
-   "url": "https://github.com/dsh-external/dsh-ui-whale",
-   "category": "fun",
-   "description": {
-    "zh": "像素鲸鱼伙伴（眨眼/摆尾/喷水/爱心）。",
-    "en": "Pixel whale companion that blinks, wags its tail and spouts hearts."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:dsh-external/dsh-ui-whale",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-whale-galgame",
-   "owner": "JAdpp",
-   "url": "https://github.com/JAdpp/dsh-whale-galgame",
-   "category": "fun",
-   "description": {
-    "zh": "多角色 Galgame 对话界面：角色与回复模型可独立切换，分角色保存好感度、记忆、对话历史与 CG 图鉴，并根据 Harness 跨会话任务事件做出角色回应。",
-    "en": "Multi-character Galgame conversation view with separate character and reply-model selection, per-character affection, memory, dialogue history, and CG galleries, plus responses informed by task events across Harness sessions."
-   },
-   "npm": null,
-   "install": "dsh plugin --profile web add github:JAdpp/dsh-whale-galgame",
-   "added": "2026-08-16"
-  }
- ]
+  "name": "awesome-dsh-plugin",
+  "url": "https://beancookie.github.io/awesome-dsh-plugin",
+  "source": "https://github.com/beancookie/awesome-dsh-plugin",
+  "updated": "2026-08-16",
+  "count": 315,
+  "categories": {
+    "ui": {
+      "zh": "UI 增强",
+      "en": "UI Enhancements"
+    },
+    "theme": {
+      "zh": "主题与外观",
+      "en": "Themes & Appearance"
+    },
+    "session": {
+      "zh": "会话与消息",
+      "en": "Sessions & Messages"
+    },
+    "memory": {
+      "zh": "记忆",
+      "en": "Memory"
+    },
+    "tools": {
+      "zh": "工具与能力",
+      "en": "Tools & Capabilities"
+    },
+    "skill": {
+      "zh": "技能包",
+      "en": "Skills"
+    },
+    "workflow": {
+      "zh": "工作流与自动化",
+      "en": "Workflow & Automation"
+    },
+    "notify": {
+      "zh": "通知与集成",
+      "en": "Notifications & Integrations"
+    },
+    "model": {
+      "zh": "模型与账号接入",
+      "en": "Models & Providers"
+    },
+    "dev": {
+      "zh": "开发与运行时",
+      "en": "Development & Runtime"
+    },
+    "fun": {
+      "zh": "娱乐",
+      "en": "Just for Fun"
+    }
+  },
+  "plugins": [
+    {
+      "name": "dsh-token-pet",
+      "owner": "pk7j7sqryy-ops",
+      "url": "https://github.com/pk7j7sqryy-ops/dsh-token-pet",
+      "category": "ui",
+      "description": {
+        "zh": "会话头部卡通用量小部件：布布玩偶 + 上下文占用/会话累计/构成，附日期周几、天气、3 天预报与极端天气预警（雨滴/雪花动画），跟随主题色。",
+        "en": "Cute token-usage widget in the session header: context occupancy, session usage and breakdown, plus date/weekday, weather, 3-day forecast and severe-weather alerts."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:pk7j7sqryy-ops/dsh-token-pet",
+      "added": "2026-08-15"
+    },
+    {
+      "name": "dsh-pet",
+      "owner": "zealot00",
+      "url": "https://github.com/zealot00/dsh-pet",
+      "category": "ui",
+      "description": {
+        "zh": "DSH Web UI 桌面宠物：精灵图动画、agent 状态联动、拖拽、闹钟（每天/一次）与番茄钟，皮肤下拉选择 + 预览。",
+        "en": "Desktop pet for the DSH Web UI: sprite-sheet animation, agent state linkage, drag, alarm (daily/one-shot) and pomodoro widgets, skin picker with preview."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:zealot00/dsh-pet",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-voice-input-plugin",
+      "owner": "Zhangbo-cn",
+      "url": "https://github.com/Zhangbo-cn/dsh-voice-input-plugin",
+      "category": "ui",
+      "description": {
+        "zh": "输入框麦克风：点击持续监控、按住对话；浏览器语音识别逐字上屏，回复由 host Edge TTS 边生成边朗读（句子切分），朗读时暂停识别防回声，点击可停止。",
+        "en": "Composer microphone: click for continuous monitoring or hold to talk; browser speech recognition types words into the composer as you speak, while replies are read aloud as they stream via host Edge TTS (sentence-split), pausing recognition while reading to avoid echo, click to stop."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Zhangbo-cn/dsh-voice-input-plugin",
+      "added": "2026-08-16"
+    },
+    {
+      "name": "dsh-tianshu-tui",
+      "owner": "huiliyi37",
+      "url": "https://github.com/huiliyi37/dsh-tianshu-tui",
+      "category": "ui",
+      "description": {
+        "zh": "DeepSeek Harness 的终端 UI（TUI）。",
+        "en": "A terminal UI (TUI) for DeepSeek Harness."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:huiliyi37/dsh-tianshu-tui",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "deepseek-harness-tui",
+      "owner": "openma-ai",
+      "url": "https://github.com/openma-ai/deepseek-harness-tui",
+      "category": "ui",
+      "description": {
+        "zh": "Rust/ratatui 终端客户端，直接使用 DSH SDK JSON-RPC 协议，支持独立运行或作为 profile bundle 加载。",
+        "en": "A Rust/ratatui terminal client that speaks the DSH SDK JSON-RPC protocol directly and runs standalone or as a profile bundle."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:openma-ai/deepseek-harness-tui",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-at-file",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/dsh-at-file",
+      "category": "ui",
+      "description": {
+        "zh": "Codex 风格的 `@file` 文件引用，输入框里直接搜索并引用工作区文件。",
+        "en": "Codex-style `@file` mentions: search workspace files in the composer and attach their contents to prompts."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/dsh-at-file",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "ui-status-label",
+      "owner": "alingalingling",
+      "url": "https://github.com/alingalingling/ui-status-label",
+      "category": "ui",
+      "description": {
+        "zh": "把鲸鱼娘思考时的 \"deep diving\" 状态文案自定义成任意你想要的样子。",
+        "en": "Customize the \"deep diving\" thinking status label to anything you like."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:alingalingling/ui-status-label",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-openpencil",
+      "owner": "ZSeven-W",
+      "url": "https://github.com/ZSeven-W/dsh-openpencil",
+      "category": "ui",
+      "description": {
+        "zh": "OpenPencil 设计预览与编辑插件。",
+        "en": "OpenPencil design preview and editing plugin."
+      },
+      "npm": "@zseven-w/dsh-openpencil",
+      "install": "dsh plugin --profile web add @zseven-w/dsh-openpencil",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-visualize",
+      "owner": "Nagi-ovo",
+      "url": "https://github.com/Nagi-ovo/dsh-visualize",
+      "category": "ui",
+      "description": {
+        "zh": "对话内生成式 UI：模型把交互式 HTML 卡片直接画进会话流，带流式预览与沙箱渲染。",
+        "en": "In-conversation generative UI: the model renders interactive HTML cards into the chat stream, with streaming preview and sandboxed rendering."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Nagi-ovo/dsh-visualize",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-side-panel",
+      "owner": "ccq1",
+      "url": "https://github.com/ccq1/dsh-side-panel",
+      "category": "ui",
+      "description": {
+        "zh": "侧边栏集成文件浏览器、终端和 Git 审查，方便预览文件。",
+        "en": "Side panel with file browser, terminal, and Git review for quick file previews."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:ccq1/dsh-side-panel",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-filetree",
+      "owner": "lak321",
+      "url": "https://github.com/lak321/dsh-filetree",
+      "category": "ui",
+      "description": {
+        "zh": "工程文件浏览器：会话视图文件页签，目录树 + VSCode 风格编辑器（C 语法高亮/行号/自动缩进/状态栏），跟随当前工作区。",
+        "en": "Project file browser: per-session file tabs, a directory tree, and a VSCode-style editor (C syntax highlighting, line numbers, auto-indent, status bar) that follows the current workspace."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:lak321/dsh-filetree",
+      "added": "2026-08-16"
+    },
+    {
+      "name": "dsh-focus-chat",
+      "owner": "dingyi222666",
+      "url": "https://github.com/dingyi222666/dsh-focus-chat",
+      "category": "ui",
+      "description": {
+        "zh": "「聚焦会话」精简视图，只关注最终产出结果。",
+        "en": "A \"focus chat\" minimal view that shows only final outputs."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:dingyi222666/dsh-focus-chat",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-genui",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/dsh-genui",
+      "category": "ui",
+      "description": {
+        "zh": "助手回复内渲染交互式 UI 组件：布局、图表、表单、测验、mermaid、3D 场景与回传事件循环。",
+        "en": "Interactive UI components rendered inline in replies: layout, charts, forms, quizzes, mermaid, 3D scenes, and an action event loop back to the model."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/dsh-genui",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-annotation",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/dsh-annotation",
+      "category": "ui",
+      "description": {
+        "zh": "选中文字→批注→随消息发送，回复按批注逐条对照。",
+        "en": "Select text → annotate → send with your message; replies map back to each annotation."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/dsh-annotation",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-navbar",
+      "owner": "vlln",
+      "url": "https://github.com/vlln/dsh-navbar",
+      "category": "ui",
+      "description": {
+        "zh": "对话节点导航条，右缘节点串快速跳转 user 消息。",
+        "en": "Conversation node navigation bar for quick jumps between user messages."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:vlln/dsh-navbar",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-message-preview",
+      "owner": "asukasec",
+      "url": "https://github.com/asukasec/dsh-message-preview",
+      "category": "ui",
+      "description": {
+        "zh": "右侧用户消息导航条，根据消息数量与可用高度自适应排布导航块，并支持悬停预览、键盘操作与点击跳转。",
+        "en": "Right-edge user-message navigator with an adaptive block layout that fits the available height, plus hover previews, keyboard controls, and click-to-jump navigation."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:asukasec/dsh-message-preview",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-task-status",
+      "owner": "vlln",
+      "url": "https://github.com/vlln/dsh-task-status",
+      "category": "ui",
+      "description": {
+        "zh": "后台任务状态条：对话页任务进度 + 实时输出 tail。",
+        "en": "Background task status bar: progress plus live output tail on the chat page."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:vlln/dsh-task-status",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-web-archive",
+      "owner": "renat3u",
+      "url": "https://github.com/renat3u/dsh-web-archive",
+      "category": "ui",
+      "description": {
+        "zh": "折叠对话中的 Think、Bash 等「无用消息」。",
+        "en": "Collapse noisy messages (Think, Bash, etc.) in conversations."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:renat3u/dsh-web-archive",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-spotlight",
+      "owner": "0xsline",
+      "url": "https://github.com/0xsline/dsh-spotlight",
+      "category": "ui",
+      "description": {
+        "zh": "键盘优先的命令面板（command palette）。",
+        "en": "Keyboard-first command palette for the DSH Web UI."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:0xsline/dsh-spotlight",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-101",
+      "owner": "bill9109",
+      "url": "https://github.com/bill9109/dsh-101",
+      "category": "ui",
+      "description": {
+        "zh": "DSH 文档阅读模式。",
+        "en": "Document reading mode for DSH."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:bill9109/dsh-101",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-drag-and-drop",
+      "owner": "bill9109",
+      "url": "https://github.com/bill9109/dsh-drag-and-drop",
+      "category": "ui",
+      "description": {
+        "zh": "跨平台文件拖拽与原始路径插入，无需复制文件。",
+        "en": "Cross-platform file drag-and-drop with raw path insertion, no file copying."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:bill9109/dsh-drag-and-drop",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-file-uploads",
+      "owner": "l541402398",
+      "url": "https://github.com/l541402398/dsh-file-uploads",
+      "category": "ui",
+      "description": {
+        "zh": "从 Web 输入框上传任意本地文件，以待发送卡片展示，并在设置中管理已存文件。",
+        "en": "Upload arbitrary local files from the Web composer, show pending cards, and manage stored files in Settings."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:l541402398/dsh-file-uploads",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-deeplink",
+      "owner": "qyw233",
+      "url": "https://github.com/qyw233/dsh-deeplink",
+      "category": "ui",
+      "description": {
+        "zh": "`?session=` / `?workspace=` 深链直达指定项目对话。",
+        "en": "Deep links: open a specific session or workspace via `?session=` / `?workspace=`."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:qyw233/dsh-deeplink",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-diff-viewer",
+      "owner": "lehhair",
+      "url": "https://github.com/lehhair/dsh-diff-viewer",
+      "category": "ui",
+      "description": {
+        "zh": "PiUI 风格 diff 查看器，替换 write/edit 工具调用的默认 DiffBlock。",
+        "en": "PiUI-style diff viewer replacing the stock DiffBlock for write/edit tool calls."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:lehhair/dsh-diff-viewer",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "ex-setting",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/ex-setting",
+      "category": "ui",
+      "description": {
+        "zh": "DSH 的设置扩展。",
+        "en": "Settings extensions for DSH."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/ex-setting",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "web-components",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/web-components",
+      "category": "ui",
+      "description": {
+        "zh": "Web Components 支持。",
+        "en": "Web Components support."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/web-components",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-turn-navigator",
+      "owner": "vibeinging",
+      "url": "https://github.com/vibeinging/dsh-turn-navigator",
+      "category": "ui",
+      "description": {
+        "zh": "对话轮次导航。",
+        "en": "Turn navigation for the DSH Web UI."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:vibeinging/dsh-turn-navigator",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-milestone",
+      "owner": "SnowCrescenter-tech",
+      "url": "https://github.com/SnowCrescenter-tech/dsh-milestone",
+      "category": "ui",
+      "description": {
+        "zh": "右侧圆点时间轴导航条，点击跳转到任意用户消息。",
+        "en": "Right-side dot-timeline rail: jump between user messages."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:SnowCrescenter-tech/dsh-milestone",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-balance-meter",
+      "owner": "Ghost011118",
+      "url": "https://github.com/Ghost011118/dsh-balance-meter",
+      "category": "ui",
+      "description": {
+        "zh": "输入框 dock 显示 DeepSeek 账户余额与会话花费，自动拉取官方定价，支持高峰/低谷计价。",
+        "en": "DeepSeek account balance and session cost in the composer dock, with auto-fetched official pricing and peak/off-peak support."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Ghost011118/dsh-balance-meter",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-opencode-go-usage",
+      "owner": "v587d",
+      "url": "https://github.com/v587d/dsh-opencode-go-usage",
+      "category": "ui",
+      "description": {
+        "zh": "在输入框上方 dock 显示 OpenCode Go 订阅用量（5h 滚动/每周/每月窗口与重置倒计时），内置凭据编辑器。",
+        "en": "OpenCode Go subscription usage (rolling/weekly/monthly windows with reset countdowns) in the composer dock, with a built-in credential editor."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:v587d/dsh-opencode-go-usage",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-cost-meter",
+      "owner": "Han-1413141",
+      "url": "https://github.com/Han-1413141/dsh-cost-meter",
+      "category": "ui",
+      "description": {
+        "zh": "会话与当日 API 费用统计、预算图框（已用%）、官方余额、历史看板，支持峰谷计价与官方价格一键同步。",
+        "en": "Per-session and daily API cost, budget with usage %, official balance, history dashboard, and one-click official price sync with peak/off-peak pricing."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Han-1413141/dsh-cost-meter",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-plugin-deepseek-balance",
+      "owner": "fishxcode",
+      "url": "https://github.com/fishxcode/dsh-plugin-deepseek-balance",
+      "category": "ui",
+      "description": {
+        "zh": "在 DSH Web 设置中展示 DeepSeek API 余额、余额趋势与每日用量图表。",
+        "en": "DeepSeek API balance, balance trend, and daily usage charts in DSH Web settings."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:fishxcode/dsh-plugin-deepseek-balance",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "ds-api-usage",
+      "owner": "Sev7een",
+      "url": "https://github.com/Sev7een/ds-api-usage",
+      "category": "ui",
+      "description": {
+        "zh": "在设置页展示 DeepSeek API 余额与最近 24 小时用量，包括估算消费、Token、请求次数和按小时时间线。",
+        "en": "DeepSeek API balance and 24-hour usage dashboard in Settings, with estimated spend, token counts, request counts, and an hourly timeline."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Sev7een/ds-api-usage",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-spend",
+      "owner": "nonewind",
+      "url": "https://github.com/nonewind/dsh-spend",
+      "category": "ui",
+      "description": {
+        "zh": "DSH Web 用量与费用统计插件：右下角悬浮窗，按模型/按天/按会话多维聚合与预计花费。",
+        "en": "Token usage and estimated spend for the dsh web UI: floating panel with per-model, per-day, and per-session stats."
+      },
+      "npm": "dsh-spend",
+      "install": "dsh plugin --profile web add dsh-spend",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-deepseek-balance",
+      "owner": "lancecheney",
+      "url": "https://github.com/lancecheney/dsh-plugins/tree/main/packages/dsh-deepseek-balance",
+      "category": "ui",
+      "description": {
+        "zh": "Session log 按钮左侧的实时计费徽章：余额、每会话消耗、峰谷/平价价格，按模型/货币/思考强度自动切换，每天抓官方定价。",
+        "en": "A real-time billing badge left of the Session log button: balance, per-conversation spend, peak/off-peak/flat pricing, auto-switching by model/currency/effort, daily official pricing fetch."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:lancecheney/dsh-plugins/tree/main/packages/dsh-deepseek-balance",
+      "added": "2026-08-15"
+    },
+    {
+      "name": "dsh-TUI",
+      "owner": "ccch1mneyyy",
+      "url": "https://github.com/ccch1mneyyy/dsh-TUI",
+      "category": "ui",
+      "description": {
+        "zh": "Claude Code 风格全屏终端 UI：像素鲸鱼顶栏、实时工作状态行、思考流式展开。",
+        "en": "Claude Code-style full-screen terminal UI: pixel-whale header, live status line, and streaming thought expansion."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:ccch1mneyyy/dsh-TUI",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "DSH-better-sidebar",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/DSH-better-sidebar",
+      "category": "ui",
+      "description": {
+        "zh": "侧边栏完整工作台：内置文件渲染编辑、终端、Git 与子代理，支持三方插件注册新 Tab。",
+        "en": "Full sidebar workbench with file rendering and editing, terminal, Git, and subagents; third-party plugins can register new tabs."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/DSH-better-sidebar",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-sticky-disclosure",
+      "owner": "Han-1413141",
+      "url": "https://github.com/Han-1413141/dsh-sticky-disclosure",
+      "category": "ui",
+      "description": {
+        "zh": "一键收起会话中所有展开的区块（Think、工具卡等），常驻计数按钮 + 自定义快捷键。",
+        "en": "One-click collapse of every expanded section (Think rows, tool cards) with a live-count pill and a customizable hotkey."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Han-1413141/dsh-sticky-disclosure",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-sticky-note",
+      "owner": "Meredith2328",
+      "url": "https://github.com/Meredith2328/dsh-sticky-note",
+      "category": "ui",
+      "description": {
+        "zh": "编辑框工具栏便签，随手记点子和 TODO，自动保存为 Markdown，一键发送到对话。",
+        "en": "Quick sticky notes on the composer toolbar: jot ideas or TODOs, auto-saved as Markdown, one click to send into the chat."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Meredith2328/dsh-sticky-note",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-web-attention-badge",
+      "owner": "Luaphes",
+      "url": "https://github.com/Luaphes/dsh-web-attention-badge",
+      "category": "ui",
+      "description": {
+        "zh": "会话需要你时三处同时亮起：角标、标签页标题计数、按状态换色的鲸鱼 favicon。",
+        "en": "Attention reminders: frame badge, tab-title count, and a status-colored whale favicon for sessions waiting for input or finished unopened."
+      },
+      "npm": "dsh-web-attention-badge",
+      "install": "dsh plugin --profile web add dsh-web-attention-badge",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-web-ui",
+      "owner": "zhu1090093659",
+      "url": "https://github.com/zhu1090093659/dsh-web-ui",
+      "category": "ui",
+      "description": {
+        "zh": "DSH Web UI 插件与皮肤合集：任务看板、git 图、右侧面板、远程移动端 UI、桌宠、实时 token 统计与皮肤中心。",
+        "en": "Plugin and skin collection for the DSH Web UI: task board, Git graph, right-side panel, remote mobile UI, pet, live token stats, and a skin center."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:zhu1090093659/dsh-web-ui",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-builtin-toggles",
+      "owner": "Starfie1d1272",
+      "url": "https://github.com/Starfie1d1272/dsh-builtin-toggles",
+      "category": "ui",
+      "description": {
+        "zh": "为 DSH Web 添加官方内置插件目录、搜索与状态说明，并提供经过审核的安全 UI 插件开关。",
+        "en": "Adds a built-in plugin catalog to DSH Web with search, status explanations, and safe toggles for audited UI plugins."
+      },
+      "npm": "dsh-builtin-toggles",
+      "install": "dsh plugin --profile web add dsh-builtin-toggles",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-ux",
+      "owner": "jiangnanquan",
+      "url": "https://github.com/jiangnanquan/dsh-ux",
+      "category": "ui",
+      "description": {
+        "zh": "Solarized 浅色主题、紧凑布局、思考/工具链折叠胶囊，以及余额、本轮成本与用量看板的 DSH Web 界面增强插件。",
+        "en": "Solarized light theme, compact layout, think/tool-chain collapse capsules, and balance, session cost, and usage dashboards for the DSH web UI."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:jiangnanquan/dsh-ux",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-hud",
+      "owner": "a903067276-rgb",
+      "url": "https://github.com/a903067276-rgb/dsh-hud",
+      "category": "ui",
+      "description": {
+        "zh": "HUD 状态面板：Git 状态、MCP 服务器、技能列表、模型与 token 用量，悬浮侧栏一览无余。",
+        "en": "HUD status panel: Git status, MCP servers, skills, model and token usage in a floating side panel."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:a903067276-rgb/dsh-hud",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-plugins#turn-scrubber",
+      "owner": "wsxwj123",
+      "url": "https://github.com/wsxwj123/dsh-plugins/tree/main/packages/turn-scrubber",
+      "category": "ui",
+      "description": {
+        "zh": "右侧紧凑回合刻度条，悬停显示回合摘要，点击跳转到对应用户回合。",
+        "en": "Compact right-edge turn rail with hover summaries and click-to-jump navigation."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:wsxwj123/dsh-plugins/tree/main/packages/turn-scrubber",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-cost-meter",
+      "owner": "Sttrevens",
+      "url": "https://github.com/Sttrevens/dsh-cost-meter",
+      "category": "ui",
+      "description": {
+        "zh": "Web UI 美元成本徽标：头部显示会话总成本、每条回复结尾显示该轮成本，悬停看分项。",
+        "en": "Per-turn USD cost badge in the Web UI: session total in the header and per-turn cost in each message footer, with a hover breakdown."
+      },
+      "npm": "@steven-wu/dsh-cost-meter",
+      "install": "dsh plugin --profile web add @steven-wu/dsh-cost-meter",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-file-mentions",
+      "owner": "a903067276-rgb",
+      "url": "https://github.com/a903067276-rgb/dsh-file-mentions",
+      "category": "ui",
+      "description": {
+        "zh": "DSH 回复中的文件路径可点击：Codex 风格行内打开、文件管理器定位、回合尾部文件 chip 列表。",
+        "en": "Clickable file paths in DSH replies: Codex-style inline open, reveal in file manager, and a mentioned-files chip list at the turn tail."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:a903067276-rgb/dsh-file-mentions",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-calculator",
+      "owner": "bobcat848",
+      "url": "https://github.com/bobcat848/dsh-calculator",
+      "category": "ui",
+      "description": {
+        "zh": "右侧面板展示 DeepSeek API 费用（当前会话 + 全部会话累计）与账户余额，内置官方计价与峰谷计价支持。",
+        "en": "DeepSeek API spend (current session and all sessions) and account balance in the aside panel, with official pricing and peak/off-peak support."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:bobcat848/dsh-calculator",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-deepseek-billing",
+      "owner": "Jolly-J",
+      "url": "https://github.com/Jolly-J/dsh-deepseek-billing",
+      "category": "ui",
+      "description": {
+        "zh": "侧边栏底部 DeepSeek 账户余额显示与会话费用估算卡片。",
+        "en": "DeepSeek account balance and per-session cost card in the sidebar foot."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Jolly-J/dsh-deepseek-billing",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-drag-and-drop",
+      "owner": "AKIRACOD",
+      "url": "https://github.com/AKIRACOD/dsh-drag-and-drop",
+      "category": "ui",
+      "description": {
+        "zh": "拖放 fork：文档以可删除「文件芯片」挂在输入框上方，不打字也能发送。",
+        "en": "File-drag fork: drop documents as removable chips above the composer, send without typing."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:AKIRACOD/dsh-drag-and-drop",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "context-vista",
+      "owner": "GooodWei",
+      "url": "https://github.com/GooodWei/context-vista",
+      "category": "ui",
+      "description": {
+        "zh": "右侧悬浮面板，环形图实时展示上下文 token 用量与费用。",
+        "en": "Right-side floating panel with a live donut chart of context token usage and cost."
+      },
+      "npm": "context-vista",
+      "install": "dsh plugin --profile web add context-vista",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-paste-input",
+      "owner": "dsh-external",
+      "url": "https://github.com/dsh-external/dsh-paste-input",
+      "category": "ui",
+      "description": {
+        "zh": "Ctrl+V 粘贴文件 / 拖拽 / 选择。",
+        "en": "Ctrl+V paste files / drag & drop / picker."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:dsh-external/dsh-paste-input",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-web-billing",
+      "owner": "bpc-oss",
+      "url": "https://github.com/bpc-oss/dsh-web-billing",
+      "category": "ui",
+      "description": {
+        "zh": "人民币/美元 token 计费，官方政策计价与逐条消息费用账本。",
+        "en": "RMB/USD token billing with official-policy pricing and a per-message cost ledger."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:bpc-oss/dsh-web-billing",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-pi-tui",
+      "owner": "lqhl",
+      "url": "https://github.com/lqhl/dsh-pi-tui",
+      "category": "ui",
+      "description": {
+        "zh": "差分渲染 TUI 前端：流式 Markdown 与工具卡片。",
+        "en": "Differential-rendering TUI front end with streaming markdown and tool cards."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:lqhl/dsh-pi-tui",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-web-panel",
+      "owner": "dsh-external",
+      "url": "https://github.com/dsh-external/dsh-web-panel",
+      "category": "ui",
+      "description": {
+        "zh": "内嵌终端 dock + Git Review + 文件视图。",
+        "en": "Embedded terminal dock + Git review + file view."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:dsh-external/dsh-web-panel",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-web-review",
+      "owner": "CanglongCl",
+      "url": "https://github.com/CanglongCl/dsh-web-review",
+      "category": "ui",
+      "description": {
+        "zh": "隔离网页预览，通过元素批注指导源码修改。",
+        "en": "Isolated web page previews with element annotations that guide source edits."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:CanglongCl/dsh-web-review",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-plugin-workshop",
+      "owner": "yyyyukari",
+      "url": "https://github.com/yyyyukari/dsh-plugin-workshop",
+      "category": "ui",
+      "description": {
+        "zh": "创意工坊式插件浏览器：一键安装/更新/卸载。",
+        "en": "Steam Workshop-style in-app plugin browser with one-click install/update/uninstall."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:yyyyukari/dsh-plugin-workshop",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-turn-index",
+      "owner": "Simon314620",
+      "url": "https://github.com/Simon314620/dsh-turn-index",
+      "category": "ui",
+      "description": {
+        "zh": "轮次索引侧边栏，滚动时自动高亮当前轮次。",
+        "en": "Turn-index sidebar with scroll-spy highlighting."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Simon314620/dsh-turn-index",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-plugin-description",
+      "owner": "MysaDC",
+      "url": "https://github.com/MysaDC/dsh-plugin-description",
+      "category": "ui",
+      "description": {
+        "zh": "为 Web 设置页插件卡片补上中英文功能说明。",
+        "en": "Bilingual descriptions on every plugin card in the Web Settings plugin list."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:MysaDC/dsh-plugin-description",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-opencodego-usage",
+      "owner": "BeiZi6",
+      "url": "https://github.com/BeiZi6/dsh-opencodego-usage",
+      "category": "ui",
+      "description": {
+        "zh": "OpenCodeGo 剩余额度监视器：输入框右下角呼吸指示灯（按剩余额度绿/黄/红），液态玻璃面板显示滚动/周/月用量窗口与重置时间，每 30 秒自动刷新，API Key 自动读取 DSH 凭据。",
+        "en": "OpenCodeGo quota monitor for the DSH Web GUI: a breathing indicator at the input's bottom-right (green/yellow/red by remaining share), a liquid-glass panel with rolling/weekly/monthly usage windows and reset times, auto-refreshing every 30 s; API key read from DSH credentials."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:BeiZi6/dsh-opencodego-usage",
+      "added": "2026-08-15"
+    },
+    {
+      "name": "dsh-galgame",
+      "owner": "Lanxing6480",
+      "url": "https://github.com/Lanxing6480/dsh-galgame",
+      "category": "ui",
+      "description": {
+        "zh": "DSH Web 聊天界面 GalGame 演出层：立绘差分、流式思考气泡、打字机对话框与 GalGame 式提问/审批选项框，可随时切回普通聊天。",
+        "en": "A visual-novel presentation layer for the DSH Web chat view: portrait diffs, streaming thought bubble, typewriter dialogue, and GalGame-style question/approval panels; switch back to the normal chat anytime."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Lanxing6480/dsh-galgame",
+      "added": "2026-08-15"
+    },
+    {
+      "name": "dsh-smooth-stream",
+      "owner": "Laplace-bit",
+      "url": "https://github.com/Laplace-bit/dsh-smooth-stream",
+      "category": "ui",
+      "description": {
+        "zh": "丝滑流式渲染：字跟着模型到达走、换行滑入、不闪，滚动归用户，尊重 `prefers-reduced-motion`。",
+        "en": "Silky streaming reveal for the Web UI: text appears at the model's arrival rate, new lines glide in, no flicker; follow stays with the user and `prefers-reduced-motion` is respected."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Laplace-bit/dsh-smooth-stream",
+      "added": "2026-08-16"
+    },
+    {
+      "name": "dsh-skin",
+      "owner": "KinGao294",
+      "url": "https://github.com/KinGao294/dsh-skin",
+      "category": "theme",
+      "description": {
+        "zh": "Codex 风格皮肤切换器 + 自定义壁纸层，可调透明度与模糊。",
+        "en": "Codex-style skin switcher plus a custom wallpaper layer with opacity and blur controls."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:KinGao294/dsh-skin",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-deep-whale",
+      "owner": "Small-tailqwq",
+      "url": "https://github.com/Small-tailqwq/dsh-deep-whale",
+      "category": "theme",
+      "description": {
+        "zh": "DSH Web 鲸鱼娘皮肤系列（深海女仆工坊 maid-atelier）。",
+        "en": "Whale-girl skin series for the DSH Web UI (maid-atelier)."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Small-tailqwq/dsh-deep-whale",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-plugins#theme-gallery",
+      "owner": "wsxwj123",
+      "url": "https://github.com/wsxwj123/dsh-plugins/tree/main/packages/theme-gallery",
+      "category": "theme",
+      "description": {
+        "zh": "15 个精选主题家族，浅深配色完整，跟随 DSH 原生浅色/深色/跟随系统模式。",
+        "en": "Fifteen curated theme families with complete light and dark palettes that follow the native Light, Dark, and Follow system modes."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:wsxwj123/dsh-plugins/tree/main/packages/theme-gallery",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-skins",
+      "owner": "dsh-external",
+      "url": "https://github.com/dsh-external/dsh-skins",
+      "category": "theme",
+      "description": {
+        "zh": "Web UI 皮肤。",
+        "en": "Web UI skins."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:dsh-external/dsh-skins",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-theme-plugin",
+      "owner": "BeiZi6",
+      "url": "https://github.com/BeiZi6/dsh-theme-plugin",
+      "category": "theme",
+      "description": {
+        "zh": "DSH Web GUI 主题工作室：5 套内置预设 + 完全可自定义的浅/深配色（强调色、背景、前景、UI 与代码字体、半透明侧栏、对比度），即时热切换并持久化到 localStorage。",
+        "en": "Theme studio for the DSH Web GUI: five built-in presets plus fully customizable light/dark palettes (accent, background, foreground, UI and code fonts, translucent sidebar, contrast), hot-swapped instantly and persisted in localStorage."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:BeiZi6/dsh-theme-plugin",
+      "added": "2026-08-15"
+    },
+    {
+      "name": "dsh-skin-switcher",
+      "owner": "zhtx2024",
+      "url": "https://github.com/zhtx2024/dsh-skin-switcher",
+      "category": "theme",
+      "description": {
+        "zh": "在设置界面新增「皮肤」页，自动发现已安装皮肤并一键切换，支持一键恢复官方默认外观。",
+        "en": "Adds a Skins page to Settings that auto-discovers installed skins for one-click switching, with one-click restore to the official default look."
+      },
+      "npm": "dsh-skin-switcher",
+      "install": "dsh plugin --profile web add dsh-skin-switcher",
+      "added": "2026-08-15"
+    },
+    {
+      "name": "dsh-premium-themes",
+      "owner": "xiaoyanzi191",
+      "url": "https://github.com/xiaoyanzi191/dsh-premium-themes",
+      "category": "theme",
+      "description": {
+        "zh": "8 套精选配色方案与自定义调色板导入（名称+方案+种子色推导完整 token 映射），设置页「调色板」行，热插拔安装。",
+        "en": "8 curated color schemes plus custom palette import (name + scheme + seed colors derive a full token map), a Palette row in General settings, hot-plug install."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:xiaoyanzi191/dsh-premium-themes",
+      "added": "2026-08-16"
+    },
+    {
+      "name": "dsh-theme-kit",
+      "owner": "ink5897",
+      "url": "https://github.com/ink5897/dsh-theme-kit",
+      "category": "theme",
+      "description": {
+        "zh": "32 款预设主题（莫兰迪 / 马卡龙 / 中国传统色）、动态与静态壁纸、纸纹纹理、分区透明度与文字深浅，附按键桌宠。",
+        "en": "32 preset themes across three palettes (Morandi, Macaron, Chinese traditional), animated and static wallpapers, paper textures, per-zone opacity and text depth, plus a keyboard desktop pet."
+      },
+      "npm": "dsh-theme-kit",
+      "install": "dsh plugin --profile web add dsh-theme-kit",
+      "added": "2026-08-16"
+    },
+    {
+      "name": "dsh-turn-rewind",
+      "owner": "Anionex",
+      "url": "https://github.com/Anionex/dsh-turn-rewind",
+      "category": "session",
+      "description": {
+        "zh": "对话回退：基于持久 Change Ledger 回滚会话与工作区状态。",
+        "en": "Rewind conversation and workspace state, powered by a persistent Change Ledger."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Anionex/dsh-turn-rewind",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-crosstalk",
+      "owner": "Jesse-njx",
+      "url": "https://github.com/Jesse-njx/dsh-crosstalk",
+      "category": "session",
+      "description": {
+        "zh": "跨会话消息：本机任意会话都可像 Claude Code 一样列出并互发消息，基于本地心跳注册表与收件箱。",
+        "en": "Cross-session messaging for DSH: any session on the machine can list and message any other, Claude Code-style, via a local heartbeat registry and inbox."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Jesse-njx/dsh-crosstalk",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-share",
+      "owner": "hellodigua",
+      "url": "https://github.com/hellodigua/dsh-share",
+      "category": "session",
+      "description": {
+        "zh": "一键分享你的对话。",
+        "en": "Share your conversations with one click."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:hellodigua/dsh-share",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-message-edit",
+      "owner": "Moeblack",
+      "url": "https://github.com/Moeblack/dsh-message-edit",
+      "category": "session",
+      "description": {
+        "zh": "基于分支的消息编辑、reroll、重试与版本时间线。",
+        "en": "Branch-based message editing, reroll, retry, and a version timeline."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Moeblack/dsh-message-edit",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-sidechain",
+      "owner": "Buyi-wsgzg",
+      "url": "https://github.com/Buyi-wsgzg/dsh-sidechain",
+      "category": "session",
+      "description": {
+        "zh": "`/side` 持续性侧会话与 `/btw` 一次性侧问，在临时 fork 中运行、不写入主会话历史。",
+        "en": "`/side` persistent side sessions and `/btw` one-shot side questions, run in a temporary fork without touching main history."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Buyi-wsgzg/dsh-sidechain",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-conversation-share",
+      "owner": "bill9109",
+      "url": "https://github.com/bill9109/dsh-conversation-share",
+      "category": "session",
+      "description": {
+        "zh": "分享任意段落的对话。",
+        "en": "Share any excerpt of a conversation."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:bill9109/dsh-conversation-share",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-explain",
+      "owner": "yuezengwu",
+      "url": "https://github.com/yuezengwu/dsh-explain",
+      "category": "session",
+      "description": {
+        "zh": "本地优先学习模式：跨会话全局学习线程、按来源讲解。",
+        "en": "Local-first learning mode: cross-session learning threads with per-source explanations."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:yuezengwu/dsh-explain",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-prompt-studio",
+      "owner": "Moeblack",
+      "url": "https://github.com/Moeblack/dsh-prompt-studio",
+      "category": "session",
+      "description": {
+        "zh": "带实时预览的用户/内置 system prompt 分节编辑器。",
+        "en": "Edit user and built-in system-prompt sections with live preview."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Moeblack/dsh-prompt-studio",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-peer-link",
+      "owner": "czm15053",
+      "url": "https://github.com/czm15053/dsh-peer-link",
+      "category": "session",
+      "description": {
+        "zh": "让 dsh 和 Claude Code 会话直接互发消息，附带可点击的会话列表卡片（搜索/刷新/弹窗发送）。",
+        "en": "Let dsh and Claude Code sessions message each other directly; comes with a clickable peer list card (sort/search/send/refresh)."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:czm15053/dsh-peer-link",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-chat-import",
+      "owner": "Nwflower",
+      "url": "https://github.com/Nwflower/dsh-chat-import",
+      "category": "session",
+      "description": {
+        "zh": "把 Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / opencode 的聊天记录全保真导入为可续聊的 DSH 会话。",
+        "en": "Import Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / opencode chat histories as resumable DeepSeek Harness sessions."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Nwflower/dsh-chat-import",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-file-claim",
+      "owner": "Nwflower",
+      "url": "https://github.com/Nwflower/dsh-file-claim",
+      "category": "session",
+      "description": {
+        "zh": "同一工作区并行多会话的文件认领与写入保护（claim/release、心跳 stale 接管、pending 三路合并）。",
+        "en": "File claim/release protection for parallel DSH sessions on the same workspace (heartbeat stale takeover, pending 3-way merge area)."
+      },
+      "npm": "dsh-file-claim",
+      "install": "dsh plugin --profile web add dsh-file-claim",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-interconnect",
+      "owner": "Chinesezjc",
+      "url": "https://github.com/Chinesezjc/dsh-interconnect",
+      "category": "session",
+      "description": {
+        "zh": "跨实例互联：经 interconnect 服务在多个 DSH 实例间转发消息与事件。",
+        "en": "Cross-instance message and event handoff between DSH instances via an interconnect server."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Chinesezjc/dsh-interconnect",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-prompt-stash",
+      "owner": "Wine-Red",
+      "url": "https://github.com/Wine-Red/dsh-prompt-stash",
+      "category": "session",
+      "description": {
+        "zh": "本地、按会话隔离的 LIFO 输入暂存：临时收起未完成的输入，之后安全恢复并继续编辑。",
+        "en": "Local, per-session LIFO prompt stash for temporarily setting aside unfinished composer text and safely restoring it later."
+      },
+      "npm": "dsh-prompt-stash",
+      "install": "dsh plugin --profile web add dsh-prompt-stash",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-session-search",
+      "owner": "dsh-external",
+      "url": "https://github.com/dsh-external/dsh-session-search",
+      "category": "session",
+      "description": {
+        "zh": "跨 dsh/Codex/Claude Code/pi/OpenCode 会话只读搜索，无索引。",
+        "en": "Index-free read-only search across dsh/Codex/Claude Code/pi/OpenCode sessions."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:dsh-external/dsh-session-search",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-trajectory-reader",
+      "owner": "flyingtimes",
+      "url": "https://github.com/flyingtimes/dsh-trajectory-reader",
+      "category": "session",
+      "description": {
+        "zh": "轨迹解读标签页：按用户轮次解读助手做了什么（需求/思路/执行/结果），规则引擎 + 可选 LLM 叙述，文件/命令/错误一目了然，用户消息原样保留。",
+        "en": "Trajectory interpretation tab: summarizes each user round — what was wanted and how the assistant fulfilled it (needs/thinking/execution/results) via a rules engine plus optional LLM narrative; files, commands and errors at a glance; user messages stay verbatim."
+      },
+      "npm": "@clarkchan/trajectory-reader",
+      "install": "dsh plugin --profile web add @clarkchan/trajectory-reader",
+      "added": "2026-08-15"
+    },
+    {
+      "name": "dsh-msgrail",
+      "owner": "futongxu9-maker",
+      "url": "https://github.com/futongxu9-maker/dsh-msgrail",
+      "category": "session",
+      "description": {
+        "zh": "对话右缘消息轨道：每条用户消息一个品牌色圆点，悬停预览、点击跳转、自动加载未加载历史，纯插件零宿主侵入。",
+        "en": "Message-index rail at the conversation's right edge: one brand-colored dot per user message, hover to preview, click to jump, auto-loads older history; pure plugin with no host patching."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:futongxu9-maker/dsh-msgrail",
+      "added": "2026-08-16"
+    },
+    {
+      "name": "dsh-context",
+      "owner": "bowenliang123",
+      "url": "https://github.com/bowenliang123/dsh-context",
+      "category": "memory",
+      "description": {
+        "zh": "上下文洞察面板：一眼看清模型上下文窗口的组成与变化——构成对照窗口大小、按请求历史趋势、压缩/注入事件、消息级 token 统计。",
+        "en": "Context insight panel: see what the model's context window is made of and how it evolves — composition vs. window size, per-request history, compression/injection events, and per-message token stats."
+      },
+      "npm": "dsh-context",
+      "install": "dsh plugin --profile web add dsh-context",
+      "added": "2026-08-16"
+    },
+    {
+      "name": "distill",
+      "owner": "LoserFox",
+      "url": "https://github.com/LoserFox/distill",
+      "category": "memory",
+      "description": {
+        "zh": "自动对话蒸馏：后台 subagent 反省 + 技能 create/update。",
+        "en": "Automatic conversation distillation: background subagent reflection + skill create/update."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:LoserFox/distill",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-mnemon",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/dsh-mnemon",
+      "category": "memory",
+      "description": {
+        "zh": "Mnemon 深度集成：本地三层记忆（Runtime Memory、可检索 Documents、受监督 Memory Spaces）。",
+        "en": "Deep Mnemon integration: local three-tier memory (Runtime Memory, retrievable Documents, supervised Memory Spaces)."
+      },
+      "npm": "dsh-mnemon",
+      "install": "dsh plugin --profile web add dsh-mnemon",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-mneme",
+      "owner": "modusensus",
+      "url": "https://github.com/modusensus/dsh-mneme",
+      "category": "memory",
+      "description": {
+        "zh": "跨会话记忆：SQLite + 可人工编辑的 Markdown 镜像，后台自动巩固（去重/合并/冲突裁决），提供 6 个记忆工具。",
+        "en": "Cross-session memory: SQLite with a human-editable Markdown mirror, background consolidation (dedup, merge, conflict resolution), and six memory tools."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:modusensus/dsh-mneme",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "nowledge-mem-deepseek-harness",
+      "owner": "nowledge-co",
+      "url": "https://github.com/nowledge-co/nowledge-mem-deepseek-harness",
+      "category": "memory",
+      "description": {
+        "zh": "给所有 AI 工具和 Agent 共用的一层记忆：注入 Context Bundle、提示时检索、MCP 工具与回合结束 DSH 线程捕获。",
+        "en": "One memory layer for every AI tool and agent: Context Bundle injection, prompt-time recall, MCP tools, and turn-end DSH thread capture."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:nowledge-co/nowledge-mem-deepseek-harness",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-memory",
+      "owner": "Jesse-njx",
+      "url": "https://github.com/Jesse-njx/dsh-memory",
+      "category": "memory",
+      "description": {
+        "zh": "基于 DSH 无损会话日志的引用式记忆：蒸馏出的事实带 `(sessionId, eventRange)` 引用，可随时展开回原始日志片段。",
+        "en": "Cited memory over DSH's lossless session log: distilled facts carry `(sessionId, eventRange)` citations that expand back to the exact original log excerpt."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Jesse-njx/dsh-memory",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-memory",
+      "owner": "flymysql",
+      "url": "https://github.com/flymysql/dsh-memory",
+      "category": "memory",
+      "description": {
+        "zh": "跨会话记忆库：remember / recall / forget 工具、每轮提示注入与设置页条目浏览。",
+        "en": "Cross-session memory vault: remember / recall / forget tools, per-turn prompt injection, and a settings-page entry browser."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:flymysql/dsh-memory",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-plugin-asmemory",
+      "owner": "Xplore-LAB",
+      "url": "https://github.com/Xplore-LAB/dsh-plugin-asmemory",
+      "category": "memory",
+      "description": {
+        "zh": "动作-状态时序记忆：记录类型化的状态与动作，做趋势、异常与因果关联分析。",
+        "en": "Action-state time memory: record typed states and actions, then analyze trends, anomalies, and causality."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Xplore-LAB/dsh-plugin-asmemory",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-memento",
+      "owner": "PerryLink",
+      "url": "https://github.com/PerryLink/dsh-memento",
+      "category": "memory",
+      "description": {
+        "zh": "有界、分层、带审批门、可审计的跨会话记忆：`ctx.memory` 服务 + 零依赖 SQLite 存储 + `memory` 工具与冻结快照注入；写入必过审批门，模型可见内容可自会话日志重建。",
+        "en": "Bounded, layered, approval-gated, auditable cross-session memory: a typed `ctx.memory` seam with a zero-dependency SQLite provider, a `memory` tool, and frozen snapshot injection; every write passes the approval gate and stays reconstructable from the session log."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:PerryLink/dsh-memento",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-file-memory",
+      "owner": "ICCuse",
+      "url": "https://github.com/ICCuse/dsh-file-memory",
+      "category": "memory",
+      "description": {
+        "zh": "文件型工作记忆：memorize/recall 把关键前提逐字保存在会话笔记文件，无损挺过上下文压缩。",
+        "en": "File-backed working memory: memorize/recall key premises verbatim in a session notes file so they survive context compaction losslessly."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:ICCuse/dsh-file-memory",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-knowledge",
+      "owner": "ICCuse",
+      "url": "https://github.com/ICCuse/dsh-knowledge",
+      "category": "memory",
+      "description": {
+        "zh": "全局知识库桥：kb_add/kb_search/kb_show/kb_timeline 读写与 Codex 共享的 D:\\knowledge（格式逐字节兼容）。",
+        "en": "Bridge into a global Markdown knowledge base shared with the Codex kb.cmd CLI: kb_add/kb_search/kb_show/kb_timeline tools with byte-compatible frontmatter."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:ICCuse/dsh-knowledge",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "kb-rag",
+      "owner": "Breeze136",
+      "url": "https://github.com/Breeze136/kb-rag",
+      "category": "memory",
+      "description": {
+        "zh": "本地文献知识库 RAG：8 个工具（PDF/文件夹/Zotero 入库、BM25+向量+重排混合检索、DOI 可点击溯源问答、范围/严格模式、去重/清空/统计），全本地 bge 嵌入 + 单文件 SQLite，实测 242 篇 86s 入库、2 万块亚秒热查询。",
+        "en": "Local literature knowledge-base RAG: 8 tools (PDF/folder/Zotero ingest, hybrid BM25+vector+reranker search, cited QA with clickable DOI links, scope/strict modes, dedup/clear/stats), all-local bge embeddings + single-file SQLite, measured 242-doc/86s ingest and sub-second hot queries on 20k chunks."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Breeze136/kb-rag",
+      "added": "2026-08-16"
+    },
+    {
+      "name": "dsh-premise-guard",
+      "owner": "ICCuse",
+      "url": "https://github.com/ICCuse/dsh-premise-guard",
+      "category": "memory",
+      "description": {
+        "zh": "压缩后前提漂移守卫：摘要丢失关键字面锚点时注入一次性提醒。",
+        "en": "Post-compaction premise-drift guard: injects a one-shot notice when a compaction summary drops a critical literal anchor."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:ICCuse/dsh-premise-guard",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "sgme",
+      "owner": "freehul",
+      "url": "https://github.com/freehul/sgme",
+      "category": "memory",
+      "description": {
+        "zh": "拾光记忆引擎（SGME）桥接：多智能体共享长期记忆（HTTP）—— L0/L1/L1.5/L2 分层提炼、按场景注入、统一检索、主动关怀信号（memory_search / wiki_search / signal_pull / signal_claim / signal_ack），npm 包名 `dsh-sgme`。",
+        "en": "ShiGuang Memory Engine (SGME) bridge: multi-agent shared long-term memory via HTTP — L0/L1/L1.5/L2 distillation, scenario-based injection, unified search, and proactive care signals (memory_search / wiki_search / signal_pull / signal_claim / signal_ack), installable as `dsh-sgme`."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:freehul/sgme",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-memory-meow",
+      "owner": "Phant0Meow",
+      "url": "https://github.com/Phant0Meow/dsh-memory-meow",
+      "category": "memory",
+      "description": {
+        "zh": "项目级跨会话记忆：PROJECT.md 快照注入首条用户消息（缓存友好）+ memory_remember 工具 + ReAct 任务结束自动反思；各项目独立记忆文件，互不互通。",
+        "en": "Project-scoped cross-session memory: PROJECT.md snapshot injected into the first user message, a memory_remember tool, and auto-reflection after ReAct tasks; each project keeps its own memory file."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Phant0Meow/dsh-memory-meow",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "billion-context-dsh",
+      "owner": "Tyan66666",
+      "url": "https://github.com/Tyan66666/billion-context-dsh",
+      "category": "memory",
+      "description": {
+        "zh": "模型驱动的上下文压缩：由模型决定何时压缩、压缩什么。",
+        "en": "Model-driven context compression: the model decides when and what to compress."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Tyan66666/billion-context-dsh",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-shared-memory",
+      "owner": "futongxu9-maker",
+      "url": "https://github.com/futongxu9-maker/dsh-shared-memory",
+      "category": "memory",
+      "description": {
+        "zh": "跨对话共享记忆：MEMORY.md + USER.md 注入每个会话系统提示词，memory 工具 + 可视化记忆面板，Hermes 式实现。",
+        "en": "Cross-conversation shared memory: MEMORY.md + USER.md injected into every session's system prompt, with a memory tool and a GUI panel (Hermes-style)."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:futongxu9-maker/dsh-shared-memory",
+      "added": "2026-08-16"
+    },
+    {
+      "name": "hkinsure",
+      "owner": "Anlushu",
+      "url": "https://github.com/Anlushu/hkinsure",
+      "category": "tools",
+      "description": {
+        "zh": "香港保险数据 MCP：260+ 真实产品、17 家保司、分红实现率，供 Hermes / dsh / Claude Code 等 AI 工具查询/对比/测算。",
+        "en": "Hong Kong insurance data MCP: 260+ real products, 17 insurers, dividend fulfillment rates. Query/compare/calculate for any AI tool (Hermes / dsh / Claude Code)."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Anlushu/hkinsure",
+      "added": "2026-08-16"
+    },
+    {
+      "name": "dsh-repo-setup",
+      "owner": "gongyijie85",
+      "url": "https://github.com/gongyijie85/dsh-repo-setup",
+      "category": "tools",
+      "description": {
+        "zh": "只读仓库体检引导工具（repo_setup_scan）：识别技术栈/测试/文档/git/数据库线索，给出技能插件、MCP 服务器与卫生文件的安装建议（claude-code-setup 的 DSH 对应）。",
+        "en": "Read-only repo bootstrap scanner (repo_setup_scan tool): detects stack/tests/docs/git/db hints and recommends skill plugins, MCP servers and hygiene files (claude-code-setup counterpart)."
+      },
+      "npm": "dsh-repo-setup",
+      "install": "dsh plugin --profile web add dsh-repo-setup",
+      "added": "2026-08-16"
+    },
+    {
+      "name": "dsh-tool-vision",
+      "owner": "gloryxpnv",
+      "url": "https://github.com/gloryxpnv/dsh-tool-vision",
+      "category": "tools",
+      "description": {
+        "zh": "为纯文本 DeepSeek Harness 提供本地优先视觉：由本地 VLM（LM Studio / Ollama / vLLM）产出结构化 JSON 证据（OCR / 版面 / 语义），零 API 成本，图片数据完全不出本机。",
+        "en": "Local-first vision for the text-only DeepSeek Harness: a local VLM (LM Studio / Ollama / vLLM) produces structured JSON evidence (OCR / layout / semantics) at zero API cost, with image data never leaving the machine."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:gloryxpnv/dsh-tool-vision",
+      "added": "2026-08-16"
+    },
+    {
+      "name": "dsh-plugin-net-access",
+      "owner": "Gumiho12345",
+      "url": "https://github.com/Gumiho12345/dsh-plugin-net-access",
+      "category": "tools",
+      "description": {
+        "zh": "DSH 的 net-access 权限模式：文件写保护不变，沙箱内 curl.exe 可用 HTTPS（Windows）。",
+        "en": "Net Access permission mode: keeps workspace-write protection while making curl.exe HTTPS work inside the sandbox (Windows)."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Gumiho12345/dsh-plugin-net-access",
+      "added": "2026-08-15"
+    },
+    {
+      "name": "coding-coach",
+      "owner": "xiehuan123",
+      "url": "https://github.com/xiehuan123/coding-coach",
+      "category": "tools",
+      "description": {
+        "zh": "Coding Coach 编程教练：面向非开发人员的 35 技能 bundle + 完整 Agent 预设（八段编排流水线 + 工程/产品/界面技能），npm 可装 `dsh plugin add coding-coach`，同时提供 Claude Code 插件。",
+        "en": "Coding Coach: a 35-skill bundle plus a full agent preset for non-developers (8-stage product→launch pipeline with engineering/product/UI skills), installable via npm (`dsh plugin add coding-coach`) and as a Claude Code plugin."
+      },
+      "npm": "coding-coach",
+      "install": "dsh plugin --profile web add coding-coach",
+      "added": "2026-08-15"
+    },
+    {
+      "name": "dsh-deepread",
+      "owner": "xiehuan123",
+      "url": "https://github.com/xiehuan123/dsh-deepread",
+      "category": "tools",
+      "description": {
+        "zh": "DeepRead 精读助手：五种精读模式（quick / deep / map 知识地图（四档置信度）/ feynman 费曼读书法 / book 全书）、批量对比、预算预检与后台任务进度透明、微信公众号链接 / .pdf 文件（内置纯 JS 提取器）/ 粘贴文本，可选导出 MD / FreeMind 思维导图（XMind 可导入）/ 编辑风网页报告。",
+        "en": "DeepRead: deep-reading assistant with five modes (quick / deep / knowledge map with four confidence levels / Feynman reading / whole book), batch comparison, budget preflight, and transparent background-job progress, from WeChat article links / local .pdf (built-in pure-JS extractor) / pasted text, with optional MD / FreeMind / styled HTML export."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:xiehuan123/dsh-deepread",
+      "added": "2026-08-15"
+    },
+    {
+      "name": "dsh-vision-router",
+      "owner": "ysr666",
+      "url": "https://github.com/ysr666/dsh-vision-router",
+      "category": "tools",
+      "description": {
+        "zh": "为纯文本 Agent 提供视觉能力：内置免 Key 视觉链 + 像素级视觉工具（看图问答、定位、裁剪、像素对比、取色、OCR、矢量化、抠图、截图）；粘贴图片即可用。",
+        "en": "Free vision for text-only agents: built-in keyless vision chain plus pixel tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots); paste an image to use it."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:ysr666/dsh-vision-router",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-undo-plugin",
+      "owner": "lire1131",
+      "url": "https://github.com/lire1131/dsh-undo-plugin",
+      "category": "tools",
+      "description": {
+        "zh": "DSH 撤销/回退系统：配置变更自动存档，一键撤销/恢复/回退到任意版本，支持 WebUI 与离线 CLI/GUI 工具（DSH 启动失败也能救）。",
+        "en": "Undo/redo & rollback system for DSH: every config change is auto-snapshotted; undo/redo/restore to any version from the WebUI or the offline CLI/GUI tools (works even when DSH fails to boot)."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:lire1131/dsh-undo-plugin",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-bash-terminal",
+      "owner": "MAXeaglet",
+      "url": "https://github.com/MAXeaglet/dsh-bash-terminal",
+      "category": "tools",
+      "description": {
+        "zh": "一个 shell 工具：Windows 上统一执行 PowerShell / Git Bash / WSL，外加交互式 PTY 终端，默认终端由用户在设置中选择。",
+        "en": "One shell tool for PowerShell / Git Bash / WSL on Windows plus an interactive PTY terminal; the default terminal is chosen by the user in DSH settings."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:MAXeaglet/dsh-bash-terminal",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-vision-toolkit",
+      "owner": "Anionex",
+      "url": "https://github.com/Anionex/dsh-vision-toolkit",
+      "category": "tools",
+      "description": {
+        "zh": "让纯文本模型更好地做视觉任务：带意图的图片问答、长截图 OCR、UI 还原等。",
+        "en": "Vision tasks for text-only models: intent-aware image Q&A, long-screenshot OCR, UI reproduction, grounding, and pixel diff."
+      },
+      "npm": "@dsh-external/dsh-vision-toolkit",
+      "install": "dsh plugin --profile web add @dsh-external/dsh-vision-toolkit",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-custom-tool",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/dsh-custom-tool",
+      "category": "tools",
+      "description": {
+        "zh": "用 Monaco 编辑器创建和管理沙箱化的自定义 JavaScript 工具。",
+        "en": "Create and manage sandboxed JavaScript tools with a Monaco editor and model-driven tool lifecycle."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/dsh-custom-tool",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-computer-use",
+      "owner": "Anionex",
+      "url": "https://github.com/Anionex/dsh-computer-use",
+      "category": "tools",
+      "description": {
+        "zh": "macOS 电脑控制：Accessibility 观测、过期状态拒绝、作用域权限与安全输入。",
+        "en": "Accessibility-first macOS computer use: fresh observations, stale-state rejection, scoped permissions, and safe input."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Anionex/dsh-computer-use",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-mobile-gui-agent",
+      "owner": "kunjinkao-os",
+      "url": "https://github.com/kunjinkao-os/dsh-mobile-gui-agent",
+      "category": "tools",
+      "description": {
+        "zh": "Android GUI Agent：ADB 截图、压缩 UI hierarchy 定位、逐步动作验证、审批和 Mobile Web 视图。",
+        "en": "Android GUI Agent with ADB screenshots, compact UI hierarchy grounding, verified iterative actions, approvals, and a Mobile Web view."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:kunjinkao-os/dsh-mobile-gui-agent",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-data-agent",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/dsh-data-agent",
+      "category": "tools",
+      "description": {
+        "zh": "让 AI 帮你连数据库、写 SQL。",
+        "en": "Let the AI connect to databases and write SQL for you."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/dsh-data-agent",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-toolkit",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/dsh-toolkit",
+      "category": "tools",
+      "description": {
+        "zh": "零依赖工具包：time / encoding / json / calculator / csv / regex / markdown / diff / stat / schema 十件套一键安装。",
+        "en": "Zero-dependency toolkit: time / encoding / json / calculator / csv / regex / markdown / diff / stat / schema — ten deterministic tools in one install."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/dsh-toolkit",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-remote",
+      "owner": "flymysql",
+      "url": "https://github.com/flymysql/dsh-remote",
+      "category": "tools",
+      "description": {
+        "zh": "远程工作区：SSH 密码或 key 连接远程主机，选取远程工作区目录，用 rw_pick_workspace / rw_list_dir / rw_read_file / rw_exec 工具在远程直接操作。",
+        "en": "Remote workspace: connect a host over SSH (password or key), pick a remote workspace directory and operate on it with rw_pick_workspace / rw_list_dir / rw_read_file / rw_exec tools."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:flymysql/dsh-remote",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-tool-csv",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/dsh-tool-csv",
+      "category": "tools",
+      "description": {
+        "zh": "CSV 解析/查询/统计/转换（RFC 4180），零依赖状态机解析器。",
+        "en": "Parse/query/aggregate/convert CSV (RFC 4180) with a zero-dependency state-machine parser."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-csv",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-tool-calculator",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/dsh-tool-calculator",
+      "category": "tools",
+      "description": {
+        "zh": "安全的数学表达式求值器，零依赖递归下降解析器。",
+        "en": "Safe math expression evaluator, zero-dependency recursive-descent parser."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-calculator",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-tool-diff",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/dsh-tool-diff",
+      "category": "tools",
+      "description": {
+        "zh": "文本/JSON/CSV/Markdown 结构化比较与 unified diff。",
+        "en": "Structured comparison and unified diffs for text/JSON/CSV/Markdown."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-diff",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-tool-encoding",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/dsh-tool-encoding",
+      "category": "tools",
+      "description": {
+        "zh": "base64/url/hex 编解码、常用哈希、UUID 生成。",
+        "en": "base64/url/hex encoding, common hashes, and UUID generation."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-encoding",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-tool-json",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/dsh-tool-json",
+      "category": "tools",
+      "description": {
+        "zh": "JMESPath 子集 JSON 查询。",
+        "en": "JSON queries with a JMESPath subset."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-json",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-tool-markdown",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/dsh-tool-markdown",
+      "category": "tools",
+      "description": {
+        "zh": "HTML↔Markdown 转换、GFM 表格规范化、目录生成。",
+        "en": "HTML↔Markdown conversion, GFM table normalization, and TOC generation."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-markdown",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-tool-regex",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/dsh-tool-regex",
+      "category": "tools",
+      "description": {
+        "zh": "正则测试/提取/安全替换/静态解释（不执行代码）。",
+        "en": "Test/extract/safe-replace/statically explain regexes without executing code."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-regex",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-tool-schema",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/dsh-tool-schema",
+      "category": "tools",
+      "description": {
+        "zh": "JSON Schema 验证：validate/paths/explain/normalize。",
+        "en": "JSON Schema validation: validate/paths/explain/normalize."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-schema",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-tool-stat",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/dsh-tool-stat",
+      "category": "tools",
+      "description": {
+        "zh": "描述统计/百分位数/频数分布/相关性。",
+        "en": "Descriptive statistics, percentiles, frequency distributions, and correlation."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-stat",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-tool-time",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/dsh-tool-time",
+      "category": "tools",
+      "description": {
+        "zh": "严格 ISO 8601 解析、IANA 时区转换、UTC 日历运算。",
+        "en": "Strict ISO 8601 parsing, IANA timezone conversion, and UTC calendar arithmetic."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-time",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-kb-sieve",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/dsh-kb-sieve",
+      "category": "tools",
+      "description": {
+        "zh": "从 md/txt/docx/pdf 构建可审计知识库包（SQLite FTS5），确定性检索与原文阅读。",
+        "en": "Build auditable KB packs (SQLite FTS5) from md/txt/docx/pdf with deterministic retrieval and original-text reading."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/dsh-kb-sieve",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-plugin-mineru",
+      "owner": "HuanLinOTO",
+      "url": "https://github.com/HuanLinOTO/dsh-plugin-mineru",
+      "category": "tools",
+      "description": {
+        "zh": "向模型暴露 MineRU 文档解析工具。",
+        "en": "Expose MineRU document parsing tools to the model."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:HuanLinOTO/dsh-plugin-mineru",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-plugin-anydoc",
+      "owner": "beancookie",
+      "url": "https://github.com/beancookie/dsh-plugin-anydoc",
+      "category": "tools",
+      "description": {
+        "zh": "将 @firecrawl/anydoc 作为 anydoc 工具注册给 Agent，把 Word/PPT/Excel/PDF/EPUB 等多种文档格式转换为 GitHub-Flavored Markdown。",
+        "en": "Registers @firecrawl/anydoc as an `anydoc` tool for the Agent, converting Word/PPT/Excel/PDF/EPUB and other document formats into GitHub-Flavored Markdown."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:beancookie/dsh-plugin-anydoc",
+      "added": "2026-08-15"
+    },
+    {
+      "name": "dsh-cowork",
+      "owner": "Jesse-njx",
+      "url": "https://github.com/Jesse-njx/dsh-cowork",
+      "category": "tools",
+      "description": {
+        "zh": "doc_read/doc_write：以有界、单元格寻址的方式读写 xlsx / pdf / docx / pptx / ipynb，另附 MCP 服务器与 CLI。",
+        "en": "Bounded, cell-addressed `doc_read`/`doc_write` for xlsx / pdf / docx / pptx / ipynb, plus an MCP server and CLI."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Jesse-njx/dsh-cowork",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-skillport",
+      "owner": "Jesse-njx",
+      "url": "https://github.com/Jesse-njx/dsh-skillport",
+      "category": "tools",
+      "description": {
+        "zh": "把已有的 Agent Skills（SKILL.md）技能库带进 DSH：扫描 Claude/Codex/Cursor/Gemini 技能目录、注入渐进式索引，按需加载技能正文。",
+        "en": "Bring your existing Agent Skills (SKILL.md) library to DSH: discover skills across Claude/Codex/Cursor/Gemini paths, inject a progressive-disclosure index, and load bodies on demand."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Jesse-njx/dsh-skillport",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "pack-agent",
+      "owner": "sakikoTGW",
+      "url": "https://github.com/sakikoTGW/pack-agent",
+      "category": "tools",
+      "description": {
+        "zh": "把 .pack.json/.pack.zip 投影到 .agent-pack/modpacks/，按工作区白名单暴露 skill。",
+        "en": "Project .pack.json/.pack.zip into .agent-pack/modpacks/ and expose skills via a workspace allow-list."
+      },
+      "npm": "@sakikotgw/pack-agent",
+      "install": "dsh plugin --profile web add @sakikotgw/pack-agent",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-tool-search",
+      "owner": "vibeinging",
+      "url": "https://github.com/vibeinging/dsh-tool-search",
+      "category": "tools",
+      "description": {
+        "zh": "按 agent 的按需工具发现与渐进式 schema 披露。",
+        "en": "Per-agent on-demand tool discovery and progressive schema disclosure."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:vibeinging/dsh-tool-search",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-openmaic",
+      "owner": "THU-MAIC",
+      "url": "https://github.com/THU-MAIC/dsh-openmaic",
+      "category": "tools",
+      "description": {
+        "zh": "OpenMAIC 教学：课堂、幻灯片、交互组件与苏格拉底式教学。",
+        "en": "OpenMAIC: classrooms, slides, interactive widgets, and Socratic teaching."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:THU-MAIC/dsh-openmaic",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-scholar",
+      "owner": "lzszq",
+      "url": "https://github.com/lzszq/dsh-scholar",
+      "category": "tools",
+      "description": {
+        "zh": "学术助手插件。",
+        "en": "Academic assistant plugin."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:lzszq/dsh-scholar",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "noatmark-dsh-plugin",
+      "owner": "ylwl1997",
+      "url": "https://github.com/ylwl1997/noatmark-dsh-plugin",
+      "category": "tools",
+      "description": {
+        "zh": "文本卫生 dsh 插件：净化不可信文本、扫描隐形字符、清洗 LLM 格式、转义 CSV 公式注入。",
+        "en": "Text hygiene as a dsh plugin: sanitize untrusted text, scan invisible characters, clean LLM formatting, and escape CSV formula injection."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:ylwl1997/noatmark-dsh-plugin",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-apple-mode",
+      "owner": "jihongboo",
+      "url": "https://github.com/jihongboo/dsh-apple-mode",
+      "category": "tools",
+      "description": {
+        "zh": "DSH 的 Xcode AI 集成：26 个 Xcode MCP 工具（mcpbridge）+ Apple 平台技能 + Xcode Intelligence 风格 persona（agent preset 或全局 bundle）。",
+        "en": "Xcode AI integration for DSH: 26 Xcode MCP tools (mcpbridge) + Apple platform skills + Xcode Intelligence-style persona (agent preset or global bundle)."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:jihongboo/dsh-apple-mode",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-continual-evolve",
+      "owner": "ZK-Andy",
+      "url": "https://github.com/ZK-Andy/dsh-continual-evolve",
+      "category": "tools",
+      "description": {
+        "zh": "持续自进化：从会话轨迹沉淀版本化、可审计、可回滚的 harness 状态（提示词/记忆/技能/子代理规格），带审查门禁与技能热加载。",
+        "en": "Continual self-evolution: versioned, auditable, rollback-safe harness state (prompts, memory, skills, subagent specs) refined from session trajectories, with review gates and hot-reloaded skills."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:ZK-Andy/dsh-continual-evolve",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-recommend",
+      "owner": "zp-home",
+      "url": "https://github.com/zp-home/dsh-recommend",
+      "category": "tools",
+      "description": {
+        "zh": "DSH 插件透明排行与推荐：每日自动抓取 `dsh-plugin` 话题生态，公开评分模型，提供 rank/search/recommend 工具与设置页榜单。",
+        "en": "Transparent rankings and recommendations for the DSH plugin ecosystem: daily auto-fetched topic data, an open scoring model, and rank/search/recommend tools with a settings-page leaderboard."
+      },
+      "npm": "dsh-recommend",
+      "install": "dsh plugin --profile web add dsh-recommend",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "modlens",
+      "owner": "liustack",
+      "url": "https://github.com/liustack/modlens",
+      "category": "tools",
+      "description": {
+        "zh": "为纯文本模型架起视觉桥梁：粘贴图片，输出结构化 JSON 证据（OCR、版面、语义）。",
+        "en": "Vision bridge for text-only models: paste an image, get structured JSON evidence (OCR, layout, semantics)."
+      },
+      "npm": "@liustack/modlens",
+      "install": "dsh plugin --profile web add @liustack/modlens",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-market",
+      "owner": "dsh-market",
+      "url": "https://github.com/dsh-market/dsh-market",
+      "category": "tools",
+      "description": {
+        "zh": "装在 DSH 里的插件市场：设置页内逛/搜全部社区插件，按分类筛选，确认后一键安装，已装插件一目了然。",
+        "en": "The plugin market inside DSH: a Settings page to browse and search the full community catalog by category, with confirmed one-click installs and an installed-plugins view."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:dsh-market/dsh-market",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-find-plugin",
+      "owner": "awesome-dsh-plugin",
+      "url": "https://github.com/awesome-dsh-plugin/dsh-find-plugin",
+      "category": "tools",
+      "description": {
+        "zh": "会话内直接找插件：按关键词/分类搜索本精选 registry，返回描述与可直接执行的安装命令。",
+        "en": "Find plugins without leaving the agent: search this curated registry by keyword or category, with ready-to-run install commands."
+      },
+      "npm": "dsh-find-plugin",
+      "install": "dsh plugin --profile web add dsh-find-plugin",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-code-intel",
+      "owner": "lonelymoon87",
+      "url": "https://github.com/lonelymoon87/dsh-code-intel",
+      "category": "tools",
+      "description": {
+        "zh": "用 Tree-sitter 建立工作区符号索引，提供词法或可选 embedding 辅助的代码检索。",
+        "en": "Indexes workspace symbols with Tree-sitter and provides lexical or optional embedding-assisted code search."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:lonelymoon87/dsh-code-intel",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-subagent-tools",
+      "owner": "lynx-gt",
+      "url": "https://github.com/lynx-gt/dsh-subagent-tools",
+      "category": "tools",
+      "description": {
+        "zh": "子代理委派的按调用覆盖：model/provider/persona/toolFilter、@preset: 引用与 provider/model 组合 id。",
+        "en": "Per-call model, provider, persona, and toolFilter overrides for subagent delegation, with @preset: references and provider/model composite ids."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:lynx-gt/dsh-subagent-tools",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-subagent-cwd",
+      "owner": "lynx-gt",
+      "url": "https://github.com/lynx-gt/dsh-subagent-cwd",
+      "category": "tools",
+      "description": {
+        "zh": "在 dsh-subagent-tools 基础上增加子代理按调用 cwd，附带所需的两个 in-process provider 补丁。",
+        "en": "Extends dsh-subagent-tools with a per-call cwd for subagents, shipped with the two in-process provider patches it requires."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:lynx-gt/dsh-subagent-cwd",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-voice",
+      "owner": "Jesse-njx",
+      "url": "https://github.com/Jesse-njx/dsh-voice",
+      "category": "tools",
+      "description": {
+        "zh": "语音输入、语音输出：把口述音频转写为用户消息（transcribe），让 agent 朗读回复（speak），本地优先，音频存于 ~/.dsh/voice。",
+        "en": "Voice notes in, spoken answers out: dictate audio that becomes user messages (transcribe), have the agent read replies aloud (speak), local-first under ~/.dsh/voice."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Jesse-njx/dsh-voice",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-voice-chat",
+      "owner": "lak321",
+      "url": "https://github.com/lak321/dsh-voice-chat",
+      "category": "tools",
+      "description": {
+        "zh": "语音对话：🎤 语音输入（Web Speech，实时中间结果可编辑）+ 🔊 自动/手动朗读回复（TTS），支持人声/语速/语调设置与识别语言（普通话/粤语等），纯客户端零密钥，朗读前自动清理 Markdown 标记。",
+        "en": "Voice chat: 🎤 speech input (Web Speech, live editable interim results) plus 🔊 automatic/manual read-aloud replies (TTS), with voice, speed, pitch and recognition-language settings (Mandarin/Cantonese, etc.); fully client-side with zero keys, and Markdown is stripped before reading."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:lak321/dsh-voice-chat",
+      "added": "2026-08-16"
+    },
+    {
+      "name": "dsh-screen-agent",
+      "owner": "lak321",
+      "url": "https://github.com/lak321/dsh-screen-agent",
+      "category": "tools",
+      "description": {
+        "zh": "桌面与网页自动化：📸 多屏截图 + 🔍 Windows OCR（文字+像素坐标）+ 🖱️ 鼠标点击/拖拽 + ⌨️ 中文打字/按键 + 🪟 窗口激活，含实战打磨的画图能力（鼠标加速度补偿、画布定位、贝塞尔曲线，可在画图中绘制图形）。",
+        "en": "Desktop and web automation: 📸 multi-screen screenshots, 🔍 Windows OCR (text + pixel coordinates), 🖱️ mouse click/drag, ⌨️ Chinese typing/keys, and 🪟 window activation, with battle-tested drawing in Paint (mouse acceleration compensation, canvas positioning, Bézier curves)."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:lak321/dsh-screen-agent",
+      "added": "2026-08-16"
+    },
+    {
+      "name": "dsh-docker",
+      "owner": "Jesse-njx",
+      "url": "https://github.com/Jesse-njx/dsh-docker",
+      "category": "tools",
+      "description": {
+        "zh": "类型安全、带护栏的容器控制：ps/logs/inspect/exec/start/stop 与 compose up/down，JSON 输出、项目感知定位、破坏性操作需审批。",
+        "en": "Typed, guarded container control: ps/logs/inspect/exec/start/stop and compose up/down with JSON output, project-aware targeting, and approval-gated destructive ops."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Jesse-njx/dsh-docker",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-excel-chat",
+      "owner": "hccccc01333",
+      "url": "https://github.com/hccccc01333/dsh-excel-chat",
+      "category": "tools",
+      "description": {
+        "zh": "在 DeepSeek Harness 里对话完成 Excel 工作：建表、编辑、修复公式、图表校验，每次编辑后自动体检公式。",
+        "en": "Talk to Excel in DeepSeek Harness: create, edit, repair, and verify spreadsheets by conversation, with automatic formula health checks after every edit."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:hccccc01333/dsh-excel-chat",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-context-proxy",
+      "owner": "EvilIrving",
+      "url": "https://github.com/EvilIrving/dsh-context-proxy",
+      "category": "tools",
+      "description": {
+        "zh": "按需取回薄层：context_query / context_slice / context_grep 三个工具读取已持久化的历史，引用可回放。",
+        "en": "Thin on-demand context retrieval: context_query / context_slice / context_grep tools that read already-persisted history back with replay-safe citations."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:EvilIrving/dsh-context-proxy",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "notes",
+      "owner": "zhaoolee",
+      "url": "https://github.com/zhaoolee/notes",
+      "category": "tools",
+      "description": {
+        "zh": "将 DSH 对话导出为锤子便签风格 PNG，或在配置的账号工作区中新建和更新 Markdown 便签。",
+        "en": "Export DSH conversations as Smartisan Notes-style PNGs, or create and update Markdown notes in a configured account-scoped workspace."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:zhaoolee/notes",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-figma-to-lottie",
+      "owner": "zimai233",
+      "url": "https://github.com/zimai233/dsh-figma-to-lottie",
+      "category": "tools",
+      "description": {
+        "zh": "将 SVG 路径与关键帧参数编译成自包含的 Lottie JSON 动画文件。",
+        "en": "Compile SVG paths and keyframe specs into self-contained Lottie JSON animation files."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:zimai233/dsh-figma-to-lottie",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-exam-countdown",
+      "owner": "zimai233",
+      "url": "https://github.com/zimai233/dsh-exam-countdown",
+      "category": "tools",
+      "description": {
+        "zh": "查询 64 场中国考试（高考/考研/四六级/CPA/法考…）的规则日期（第二个周六、第一个周日）与倒计时。",
+        "en": "Query 64 Chinese exams (高考/考研/四六级/CPA/法考…) with rule-aware date math (2nd-Saturday, 1st-Sunday) and countdowns."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:zimai233/dsh-exam-countdown",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-wash-calendar",
+      "owner": "zimai233",
+      "url": "https://github.com/zimai233/dsh-wash-calendar",
+      "category": "tools",
+      "description": {
+        "zh": "基于纯日期数学的周期习惯排程：下次发生日、区间排程与逾期提醒。",
+        "en": "Recurring-habit scheduling from pure date math: next occurrence, range schedules, and overdue advice."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:zimai233/dsh-wash-calendar",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-adhd-copilot",
+      "owner": "zimai233",
+      "url": "https://github.com/zimai233/dsh-adhd-copilot",
+      "category": "tools",
+      "description": {
+        "zh": "ADHD 行为辅导技能：任务拆解、事项过载管理、启动仪式与失败重启。",
+        "en": "ADHD behavioral coaching skill: task breakdown, overwhelm management, launch rituals, and failure recovery."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:zimai233/dsh-adhd-copilot",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-image-search",
+      "owner": "zimai233",
+      "url": "https://github.com/zimai233/dsh-image-search",
+      "category": "tools",
+      "description": {
+        "zh": "多引擎反向识图聚合：Google Lens、百度、Yandex、TinEye、SauceNAO、IQDB、Ascii2d。",
+        "en": "Multi-engine reverse image search aggregator: Google Lens, Baidu, Yandex, TinEye, SauceNAO, IQDB, Ascii2d."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:zimai233/dsh-image-search",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-video-downloader",
+      "owner": "zimai233",
+      "url": "https://github.com/zimai233/dsh-video-downloader",
+      "category": "tools",
+      "description": {
+        "zh": "检测并下载 B站/YouTube/抖音/小红书视频媒体，带清晰度与格式分析。",
+        "en": "Detect and download media from Bilibili/YouTube/Douyin/Xiaohongshu with quality and format analysis."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:zimai233/dsh-video-downloader",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-plugin-knowledge-graph",
+      "owner": "Luke-Yong",
+      "url": "https://github.com/Luke-Yong/dsh-plugin-knowledge-graph",
+      "category": "tools",
+      "description": {
+        "zh": "基于代码库知识图谱的 read_graph 工具（CONTAINS / EXPORTS / IMPORTS / IMPORTS_SYMBOL 关系）。",
+        "en": "A read_graph tool backed by a codebase knowledge graph (CONTAINS / EXPORTS / IMPORTS / IMPORTS_SYMBOL relations)."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Luke-Yong/dsh-plugin-knowledge-graph",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "modsearch",
+      "owner": "liustack",
+      "url": "https://github.com/liustack/modsearch",
+      "category": "tools",
+      "description": {
+        "zh": "纯文本 agent 的联网搜索桥：搜索网页与 X，返回结构化 JSON 证据（search/fetch/引用）。",
+        "en": "Web search bridge for text-only agents: ask the web or X, get structured JSON evidence (search, fetch, citations)."
+      },
+      "npm": "@liustack/modsearch",
+      "install": "dsh plugin --profile web add @liustack/modsearch",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "argo",
+      "owner": "taxueseek",
+      "url": "https://github.com/taxueseek/argo",
+      "category": "tools",
+      "description": {
+        "zh": "专为 agent 打造的搜索工具：多语言，覆盖中文/英文/学术/代码/购物/金融/新闻/百科。",
+        "en": "Search built for agents: multilingual coverage across web, academic, code, shopping, finance, news, and encyclopedias."
+      },
+      "npm": "argo-search",
+      "install": "dsh plugin --profile web add argo-search",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-web-search-exa",
+      "owner": "TonyDua",
+      "url": "https://github.com/TonyDua/dsh-web-search-exa",
+      "category": "tools",
+      "description": {
+        "zh": "ctx.web 接缝的零配置 Exa 网页搜索提供方：无 API key 时走匿名 MCP 兜底，配 key 时走 REST 搜索。",
+        "en": "Zero-config Exa web search provider for the ctx.web seam: anonymous MCP fallback without an API key, plus keyed REST search."
+      },
+      "npm": "@tonydua/dsh-web-search-exa",
+      "install": "dsh plugin --profile web add @tonydua/dsh-web-search-exa",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-browser",
+      "owner": "Lum1104",
+      "url": "https://github.com/Lum1104/dsh-browser",
+      "category": "tools",
+      "description": {
+        "zh": "Chrome 侧边栏扩展，让 DSH 直接操控你的浏览器，无需视觉能力。",
+        "en": "Chrome sidebar extension that lets DSH operate your browser directly, no vision capabilities required."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Lum1104/dsh-browser",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-webui-market-plugin",
+      "owner": "Sanqi-normal",
+      "url": "https://github.com/Sanqi-normal/dsh-webui-market-plugin",
+      "category": "tools",
+      "description": {
+        "zh": "dsh Web GUI 内的社区插件市场：浏览 awesome-dsh-plugin.com 目录，从 设置 → 插件 → 插件市场 安装/卸载插件到 profile。",
+        "en": "In-harness plugin market for the dsh web GUI: browse the awesome-dsh-plugin.com catalog and install/uninstall plugins into a profile from Settings → Plugins → Plugin Market."
+      },
+      "npm": "@sanqi-normal/dsh-webui-market-plugin",
+      "install": "dsh plugin --profile web add @sanqi-normal/dsh-webui-market-plugin",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "trio",
+      "owner": "huey1in",
+      "url": "https://github.com/huey1in/trio",
+      "category": "tools",
+      "description": {
+        "zh": "浏览器自动化（Playwright，带实时画面）+ MCP Server（把 DSH agent 暴露给任何 MCP 客户端）+ GitHub issue/PR/webhook 评审工具。",
+        "en": "Browser automation (Playwright) with a live view, an MCP server exposing DSH agents to any MCP client, and GitHub issue/PR/webhook review tools."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:huey1in/trio",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-adb",
+      "owner": "SamXiaBing",
+      "url": "https://github.com/SamXiaBing/dsh-adb",
+      "category": "tools",
+      "description": {
+        "zh": "ADB 设备·台架运维工具集：设备发现、结构化 logcat（后台采集）、apk 安装、文件 pull/push、性能快照。",
+        "en": "ADB device & bench operations for DSH: device discovery, structured logcat (background streaming), apk install, file pull/push, and dumpsys performance snapshots."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:SamXiaBing/dsh-adb",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-backup",
+      "owner": "xiaoyuyu6420",
+      "url": "https://github.com/xiaoyuyu6420/dsh-backup",
+      "category": "tools",
+      "description": {
+        "zh": "一键备份 DSH 用户数据：/backup 命令、定时自动备份、sha256 校验与自动轮换。",
+        "en": "One-command backup of DSH user data: /backup, scheduled auto-backup, sha256 checksums and rotation."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:xiaoyuyu6420/dsh-backup",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-hdc-bridge",
+      "owner": "1na-ko",
+      "url": "https://github.com/1na-ko/dsh-hdc-bridge",
+      "category": "tools",
+      "description": {
+        "zh": "鸿蒙设备桥：hdc 截图/装包/日志/崩溃/UI 自动化闭环（配 read_image 看图），官方优先版本化 API 知识层（SDK .d.ts + 离线随包文档），以及 DevEco CLI 构建/签名/lint 通道。",
+        "en": "HarmonyOS device bridge: hdc screenshot/install/log/crash/UI automation loop with read_image, official-first versioned API knowledge (SDK .d.ts + offline bundled docs), and a DevEco CLI build/sign/lint lane."
+      },
+      "npm": "dsh-hdc-bridge",
+      "install": "dsh plugin --profile web add dsh-hdc-bridge",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-plugin",
+      "owner": "PicGo",
+      "url": "https://github.com/PicGo/dsh-plugin",
+      "category": "tools",
+      "description": {
+        "zh": "通过 PicGo 已有配置（PicGo Cloud、GitHub、S3、腾讯云 COS、七牛，或任意已安装的上传插件）把本地图片和文件上传到图床，提供 `picgo_upload` 工具与 `/picgo` 命令。",
+        "en": "Upload local images and files to your image host through PicGo's existing configuration (PicGo Cloud, GitHub, S3, COS, Qiniu, or any installed uploader plugin), via a `picgo_upload` tool and a `/picgo` command."
+      },
+      "npm": "@picgo/dsh-plugin",
+      "install": "dsh plugin --profile web add @picgo/dsh-plugin",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-file-mount",
+      "owner": "acefun29",
+      "url": "https://github.com/acefun29/dsh-file-mount",
+      "category": "tools",
+      "description": {
+        "zh": "文件增量挂载与重复读取去重：已挂载行范围不重复进上下文。",
+        "en": "Incremental file mounting with read dedupe: mounted line ranges are never re-sent to the model."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:acefun29/dsh-file-mount",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-learn-everything",
+      "owner": "cendaifeng",
+      "url": "https://github.com/cendaifeng/dsh-learn-everything",
+      "category": "tools",
+      "description": {
+        "zh": "费曼学习法教学闭环，渲染为富 HTML 教学卡片。",
+        "en": "Feynman learning-mode loop rendered as rich HTML lesson cards."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:cendaifeng/dsh-learn-everything",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-news-plugin",
+      "owner": "canghai666x",
+      "url": "https://github.com/canghai666x/dsh-news-plugin",
+      "category": "tools",
+      "description": {
+        "zh": "RSS 新闻采集工具，抓取 10+ 中英文源为结构化条目。",
+        "en": "RSS news fetch tool that grabs 10+ CN/EN feeds into structured items."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:canghai666x/dsh-news-plugin",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-office",
+      "owner": "dsh-external",
+      "url": "https://github.com/dsh-external/dsh-office",
+      "category": "tools",
+      "description": {
+        "zh": "模型读写 Office 文件，web 客户端 docx/pdf 预览。",
+        "en": "Model reads/edits Office files with docx/pdf preview in the web client."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:dsh-external/dsh-office",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-browser-panel",
+      "owner": "dsh-external",
+      "url": "https://github.com/dsh-external/dsh-browser-panel",
+      "category": "tools",
+      "description": {
+        "zh": "WebUI 内嵌有头浏览器，模型实时操控、0 视觉依赖。",
+        "en": "Headed browser embedded in the WebUI, model-driven and zero vision deps."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:dsh-external/dsh-browser-panel",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "browser4-dsh",
+      "owner": "dsh-external",
+      "url": "https://github.com/dsh-external/browser4-dsh",
+      "category": "tools",
+      "description": {
+        "zh": "Browser4 AI-native 浏览器引擎（skills）。",
+        "en": "Browser4 AI-native browser engine exposed as skills."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:dsh-external/browser4-dsh",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-harness-mcp-server",
+      "owner": "chushixixin",
+      "url": "https://github.com/chushixixin/dsh-harness-mcp-server",
+      "category": "tools",
+      "description": {
+        "zh": "MCP server 让任意 MCP 客户端驱动 Harness agent。",
+        "en": "MCP server that lets any MCP client drive the Harness agent."
+      },
+      "npm": "@chushixixin/dsh-harness-mcp-server",
+      "install": "dsh plugin --profile web add @chushixixin/dsh-harness-mcp-server",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-tool-git",
+      "owner": "lxj808624",
+      "url": "https://github.com/lxj808624/dsh-tool-git",
+      "category": "tools",
+      "description": {
+        "zh": "结构化 Git 工具（status/diff/log/branch/stage/commit）+ 破坏性命令安全护栏。",
+        "en": "Structured Git tools (status/diff/log/branch/stage/commit) with a destructive-command guard."
+      },
+      "npm": "dsh-tool-git",
+      "install": "dsh plugin --profile web add dsh-tool-git",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-report-studio",
+      "owner": "ciceroyang",
+      "url": "https://github.com/ciceroyang/dsh-report-studio",
+      "category": "tools",
+      "description": {
+        "zh": "把 DSH 会话一键变成日报/周报/交接文档/文章，附可验证凭据。",
+        "en": "Turn a DSH session into daily/weekly/handoff/article reports with verifiable receipts."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:ciceroyang/dsh-report-studio",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-plugin-writing-guard",
+      "owner": "xmutfyh",
+      "url": "https://github.com/xmutfyh/dsh-plugin-writing-guard",
+      "category": "tools",
+      "description": {
+        "zh": "论文写作守卫：本地规则扫描修改过程残留、防御性写作与 AI 写作痕迹（破折号滥用、不是X而是Y、LLM 高频词、三连排比），论文文件写入后增量自动审计（writing_audit / writing_rules）。",
+        "en": "Academic writing guard: local-regex linter for revision-process residue, defensive writing and AI-writing tells (em-dash abuse, not-X-but-Y, LLM word spikes, rule of three), with incremental auto-audit on paper file writes (writing_audit + writing_rules)."
+      },
+      "npm": "dsh-plugin-writing-guard",
+      "install": "dsh plugin --profile web add dsh-plugin-writing-guard",
+      "added": "2026-08-15"
+    },
+    {
+      "name": "dsh-plugin-grok2api-media-tool",
+      "owner": "lsjspl",
+      "url": "https://github.com/lsjspl/dsh-plugin-grok2api-media-tool",
+      "category": "tools",
+      "description": {
+        "zh": "让 dsh 通过 grok2api 的 API 获得生成图片与视频能力。",
+        "en": "Gives dsh the ability to generate images and videos through the grok2api API."
+      },
+      "npm": "dsh-plugin-grok2api-media-tool",
+      "install": "dsh plugin --profile web add dsh-plugin-grok2api-media-tool",
+      "added": "2026-08-15"
+    },
+    {
+      "name": "dsh-path-reveal",
+      "owner": "futongxu9-maker",
+      "url": "https://github.com/futongxu9-maker/dsh-path-reveal",
+      "category": "tools",
+      "description": {
+        "zh": "点击消息里的 Windows 绝对路径在资源管理器中打开所在文件夹（文件定位选中/目录直接打开）。",
+        "en": "Click any absolute Windows path in DSH messages to reveal it in Explorer (select the file or open the folder)."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:futongxu9-maker/dsh-path-reveal",
+      "added": "2026-08-16"
+    },
+    {
+      "name": "dsh-sxs-anti-bot-http",
+      "owner": "yangyunsong023",
+      "url": "https://github.com/yangyunsong023/dsh-sxs-anti-bot-http",
+      "category": "tools",
+      "description": {
+        "zh": "反爬 HTTP 工具：UA 池轮换、指数退避重试、反爬墙检测（验证码/安全验证）与自适应限流，提炼自 SXS 生产采集体系（每日数百万请求）——工具：`sxs_fetch` / `sxs_fetch_json` / `sxs_rate_status`。",
+        "en": "Anti-bot HTTP fetch tools hardened by SXS's production scraping stack (millions of requests/day): UA-pool rotation, retry with exponential backoff, anti-bot wall detection (captcha / verification challenges) and adaptive rate limiting — tools: `sxs_fetch` / `sxs_fetch_json` / `sxs_rate_status`."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:yangyunsong023/dsh-sxs-anti-bot-http",
+      "added": "2026-08-16"
+    },
+    {
+      "name": "dsh-sxs-news-collector",
+      "owner": "yangyunsong023",
+      "url": "https://github.com/yangyunsong023/dsh-sxs-news-collector",
+      "category": "tools",
+      "description": {
+        "zh": "时事热点采集：一次调用聚合百度热搜 / 头条热榜 / 抖音热点 / 微博热搜（微博可选 cookie），返回标题+热度值，供内容创作借势——工具：`sxs_news_hot`。",
+        "en": "Trending-topics collector aggregating Baidu / Toutiao / Douyin / Weibo hot lists in one call (Weibo optional cookie), returning titles with heat values for content creators — tool: `sxs_news_hot`."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:yangyunsong023/dsh-sxs-news-collector",
+      "added": "2026-08-16"
+    },
+    {
+      "name": "dsh-llm-inspector",
+      "owner": "cdxiaodong",
+      "url": "https://github.com/cdxiaodong/dsh-llm-inspector",
+      "category": "tools",
+      "description": {
+        "zh": "统一 LLM 请求/响应检查器：调 reasoning effort、外部思考(think)导出、流量与包分析。",
+        "en": "Unified LLM request/response inspector: reasoning-effort tuning, external-think export, traffic & bundle analysis."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:cdxiaodong/dsh-llm-inspector",
+      "added": "2026-08-16"
+    },
+    {
+      "name": "dsh-ponytail",
+      "owner": "gongyijie85",
+      "url": "https://github.com/gongyijie85/dsh-ponytail",
+      "category": "skill",
+      "description": {
+        "zh": "最懒资深工程师模式（Ponytail）的 DSH 移植：6 个技能（ponytail、ponytail-audit、ponytail-debt、ponytail-gain、ponytail-help、ponytail-review），改编自 DietrichGebert/ponytail（MIT）。",
+        "en": "Ponytail, lazy senior dev mode, for DSH: 6 skills (ponytail, ponytail-audit, ponytail-debt, ponytail-gain, ponytail-help, ponytail-review) adapted from DietrichGebert/ponytail (MIT)."
+      },
+      "npm": "dsh-ponytail-skills",
+      "install": "dsh plugin --profile web add dsh-ponytail-skills",
+      "added": "2026-08-16"
+    },
+    {
+      "name": "skills",
+      "owner": "creght-dev",
+      "url": "https://github.com/creght-dev/skills",
+      "category": "skill",
+      "description": {
+        "zh": "Creght 平台建站技能包：CLI 拉取/推送同步、页面与组件规范、CMS、表单、Auth、SEO、发布与版本回滚。",
+        "en": "Skills for building websites on the Creght platform: CLI pull/push sync, page and component conventions, CMS, forms, auth, SEO, publishing and version rollback."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:creght-dev/skills",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "Code2Skill",
+      "owner": "leechen298",
+      "url": "https://github.com/leechen298/Code2Skill",
+      "category": "skill",
+      "description": {
+        "zh": "从现有代码生成 Function、MCP、Agent Skill 和离线测试包，并作为可安装的 DSH Bundle 分发。",
+        "en": "Generates Function, MCP, Agent Skill, and offline test packages from existing code as an installable DSH bundle."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:leechen298/Code2Skill",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-reverse-skill",
+      "owner": "dhicoc",
+      "url": "https://github.com/dhicoc/dsh-reverse-skill",
+      "category": "skill",
+      "description": {
+        "zh": "完整 reverse-skill 技能包（85 个 SKILL.md）的 DeepSeek Harness 插件：面向逆向工程、授权渗透测试与安全研究的技能路由包。",
+        "en": "Complete reverse-skill pack (85 SKILL.md files) as a DeepSeek Harness plugin: a skill router for reverse engineering, authorized penetration testing, and security research."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:dhicoc/dsh-reverse-skill",
+      "added": "2026-08-15"
+    },
+    {
+      "name": "mattpocock-skills-dsh",
+      "owner": "gongyijie85",
+      "url": "https://github.com/gongyijie85/mattpocock-skills-dsh",
+      "category": "skill",
+      "description": {
+        "zh": "Matt Pocock 完整发布技能集（25 个 SKILL.md：grilling、writing-for-agents、wait-what、TDD、code-review、wayfinder、ask-matt 路由等）的 DeepSeek Harness 插件：改编自 mattpocock/skills（MIT）。",
+        "en": "Matt Pocock's full promoted skill set (25 SKILL.md files: grilling, writing-for-agents, wait-what, TDD, code-review, wayfinder, ask-matt router and more) as a DeepSeek Harness plugin, adapted from mattpocock/skills (MIT)."
+      },
+      "npm": "mattpocock-skills-dsh",
+      "install": "dsh plugin --profile web add mattpocock-skills-dsh",
+      "added": "2026-08-16"
+    },
+    {
+      "name": "mattpocock-skills-dsh-zh",
+      "owner": "gongyijie85",
+      "url": "https://github.com/gongyijie85/mattpocock-skills-dsh-zh",
+      "category": "skill",
+      "description": {
+        "zh": "Matt Pocock 技能中文版的 DeepSeek Harness 插件：25 个 SKILL.md 正文全译中文（技术术语保留英文并附注释），改编自 mattpocock/skills（MIT）。",
+        "en": "Matt Pocock's skills in Chinese for DSH: all 25 SKILL.md translated to natural Chinese (technical terms kept in English with glosses), adapted from mattpocock/skills (MIT)."
+      },
+      "npm": "mattpocock-skills-dsh-zh",
+      "install": "dsh plugin --profile web add mattpocock-skills-dsh-zh",
+      "added": "2026-08-16"
+    },
+    {
+      "name": "dsh-usage-billing",
+      "owner": "940842546",
+      "url": "https://github.com/940842546/dsh-usage-billing",
+      "category": "workflow",
+      "description": {
+        "zh": "用量与消费统计：8/17 调价前后峰谷计费，主界面汇总面板、按会话明细与用量热力图。",
+        "en": "Usage and cost statistics with peak/off-peak pricing after the 2026-08-17 rate change, a floating summary panel, per-session breakdowns, and a usage heatmap."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:940842546/dsh-usage-billing",
+      "added": "2026-08-15"
+    },
+    {
+      "name": "dsh_workflow",
+      "owner": "icetomoyo",
+      "url": "https://github.com/icetomoyo/dsh_workflow",
+      "category": "workflow",
+      "description": {
+        "zh": "把 UltraCode 式多 Agent 调度带给 DSH：可生成、可保存、可治理、可观察、可恢复的 Workflow 层。",
+        "en": "UltraCode-style multi-agent orchestration: a generatable, savable, governable, observable, resumable workflow layer."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:icetomoyo/dsh_workflow",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-agent-teams",
+      "owner": "NanmiCoder",
+      "url": "https://github.com/NanmiCoder/dsh-agent-teams",
+      "category": "workflow",
+      "description": {
+        "zh": "AgentTeams 多智能体团队。",
+        "en": "AgentTeams multi-agent teams."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:NanmiCoder/dsh-agent-teams",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-automation",
+      "owner": "titanwings",
+      "url": "https://github.com/titanwings/dsh-automation",
+      "category": "workflow",
+      "description": {
+        "zh": "定时任务：让 Coding 任务按计划在全新 Agent Session 中运行，保留可审计历史。",
+        "en": "Scheduled coding runs in fresh agent sessions with auditable history."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:titanwings/dsh-automation",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-plugin-automations",
+      "owner": "Sev7een",
+      "url": "https://github.com/Sev7een/dsh-plugin-automations",
+      "category": "workflow",
+      "description": {
+        "zh": "设置页定时任务：支持准点或 DeepSeek 谷时段执行、单次/每日重复，并持久化任务状态。",
+        "en": "Settings-based scheduled tasks that run on time or during DeepSeek off-peak hours, with one-time and daily schedules backed by durable task state."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Sev7een/dsh-plugin-automations",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-routines",
+      "owner": "Jesse-njx",
+      "url": "https://github.com/Jesse-njx/dsh-routines",
+      "category": "workflow",
+      "description": {
+        "zh": "定时 Agent：按 cron 计划运行 prompt，把摘要送到你已有的地方，内置重叠/漏跑/超时安全策略。",
+        "en": "Scheduled agents on a cron: run a prompt on a schedule and get the digest where you already are, with overlap/missed-run/timeout safety defaults."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Jesse-njx/dsh-routines",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-plannotator",
+      "owner": "titanwings",
+      "url": "https://github.com/titanwings/dsh-plannotator",
+      "category": "workflow",
+      "description": {
+        "zh": "计划批注：选中计划原文逐条批注，结构化反馈送回 Agent。",
+        "en": "Plan review with anchored annotations and structured feedback back to the agent."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:titanwings/dsh-plannotator",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-loop",
+      "owner": "vlln",
+      "url": "https://github.com/vlln/dsh-loop",
+      "category": "workflow",
+      "description": {
+        "zh": "定时循环：`/loop` 命令 + loop 工具 + 活动状态条。",
+        "en": "Recurring loops: `/loop` command + loop tool + activity status bar."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:vlln/dsh-loop",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-sentinel",
+      "owner": "fuhefei",
+      "url": "https://github.com/fuhefei/dsh-sentinel",
+      "category": "workflow",
+      "description": {
+        "zh": "条件驱动唤醒：file/command/http/process/webhook 持久监视，触发即唤醒 agent。",
+        "en": "Condition-driven wakeup: durable file/command/http/process/webhook watches that wake the agent."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:fuhefei/dsh-sentinel",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-deep-research",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/dsh-deep-research",
+      "category": "workflow",
+      "description": {
+        "zh": "自适应深度研究编排器（基于官方 workflow 引擎）。",
+        "en": "Adaptive deep-research orchestrator built on the official workflow engine."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/dsh-deep-research",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-inspect",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/dsh-inspect",
+      "category": "workflow",
+      "description": {
+        "zh": "发现问题→修复交付→质量复查的对抗式闭环工具集。",
+        "en": "Adversarial checkup → fix → review loop toolset."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/dsh-inspect",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-track",
+      "owner": "fakechris",
+      "url": "https://github.com/fakechris/dsh-track",
+      "category": "workflow",
+      "description": {
+        "zh": "嵌入式任务管理引擎：决策点协议、念头捕获墙、Linear 形 issue 存储。",
+        "en": "Embedded task management engine: decision-point protocol, idea capture wall, Linear-style issue store."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:fakechris/dsh-track",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-advisor",
+      "owner": "btspoony",
+      "url": "https://github.com/btspoony/dsh-advisor",
+      "category": "workflow",
+      "description": {
+        "zh": "搭配一个副模型，每轮被动审查并注入见解。",
+        "en": "Pair a second model that passively reviews each turn and injects notes."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:btspoony/dsh-advisor",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-specflow",
+      "owner": "lonelymoon87",
+      "url": "https://github.com/lonelymoon87/dsh-specflow",
+      "category": "workflow",
+      "description": {
+        "zh": "增加规格工件、技能、命令、由 goal 驱动的实施流程和任务进度上下文。",
+        "en": "Adds specification artifacts, skills, commands, goal-backed implementation, and task-progress context."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:lonelymoon87/dsh-specflow",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-science",
+      "owner": "biociao",
+      "url": "https://github.com/biociao/dsh-science",
+      "category": "workflow",
+      "description": {
+        "zh": "面向 DSH 的 Claude Science 式科研工作台：ReAct 研究循环引擎（research_* 工具）、带溯源的版本化工件（artifact_* 工具）与面向基因组/病原体/生物信息的 10 个科研技能。",
+        "en": "Claude Science-style research workbench: ReAct research-loop engine (research_* tools), versioned artifacts with provenance (artifact_* tools), and 10 science skills for genomics/pathogens/bioinformatics."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:biociao/dsh-science",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-proof",
+      "owner": "EvilIrving",
+      "url": "https://github.com/EvilIrving/dsh-proof",
+      "category": "workflow",
+      "description": {
+        "zh": "独立只读验收层：顶层 turn 收尾前 spawn 只读 verifier，未通过时把缺口注回主 agent。",
+        "en": "Independent read-only acceptance layer: spawns a read-only verifier before each top-level turn closes and steers non-pass gaps back into the agent."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:EvilIrving/dsh-proof",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-doublecheck",
+      "owner": "PerryLink",
+      "url": "https://github.com/PerryLink/dsh-doublecheck",
+      "category": "workflow",
+      "description": {
+        "zh": "工程纪律守门：动笔前审讯需求，红绿测试证据门，交付后对抗评审（grill-requirements 技能 + 工具策略门）。",
+        "en": "Engineering-discipline guard: grill the requirements before the first edit, enforce red/green test evidence gates, and audit the delivery with a forked adversary (grill-requirements skill + tool-policy gates)."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:PerryLink/dsh-doublecheck",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "mstar-harness",
+      "owner": "btspoony",
+      "url": "https://github.com/btspoony/mstar-harness",
+      "category": "workflow",
+      "description": {
+        "zh": "技能驱动的 harness/loop 工程化工作流插件。",
+        "en": "Skill-driven harness/loop engineering workflow agent plugin."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:btspoony/mstar-harness",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-approval-llm",
+      "owner": "Letter2025",
+      "url": "https://github.com/Letter2025/dsh-approval-llm",
+      "category": "workflow",
+      "description": {
+        "zh": "基于模型的权限审批：由独立审查模型自动应答 approval 权限请求。",
+        "en": "Model-based permission approval: an approval-request answerer backed by a separate reviewer model."
+      },
+      "npm": "dsh-approval-llm",
+      "install": "dsh plugin --profile web add dsh-approval-llm",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-permissions",
+      "owner": "940842546",
+      "url": "https://github.com/940842546/dsh-permissions",
+      "category": "workflow",
+      "description": {
+        "zh": "Claude Code 风格权限规则引擎：hard/deny/ask/allow 四级规则（hard 高于全访问、不可豁免）、workspace 作用域、通配符路径保护、可视化草稿式编辑器，规则持久化于 settings.yaml。",
+        "en": "Claude Code-style permission rules engine: hard/deny/ask/allow tiers with a hard tier above full access, workspace-scoped rules, wildcard path protection, and a visual staged editor; rules persist in settings.yaml."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:940842546/dsh-permissions",
+      "added": "2026-08-16"
+    },
+    {
+      "name": "dsh-model-failover",
+      "owner": "Letter2025",
+      "url": "https://github.com/Letter2025/dsh-model-failover",
+      "category": "workflow",
+      "description": {
+        "zh": "两级模型熔断与回退：模型或平台连续失败后自动熔断，并把下一个请求路由到配置好的备用模型。",
+        "en": "Two-level model circuit breaker with failover: trip a model or a whole provider after repeated request failures and route the next request to a configured fallback."
+      },
+      "npm": "dsh-model-failover",
+      "install": "dsh plugin --profile web add dsh-model-failover",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-plan-execute",
+      "owner": "dsh-external",
+      "url": "https://github.com/dsh-external/dsh-plan-execute",
+      "category": "workflow",
+      "description": {
+        "zh": "plan/execute 双模型路由：规划模型思考、执行模型干活。",
+        "en": "Dual-model plan/execute routing: a planner model thinks, an executor model acts."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:dsh-external/dsh-plan-execute",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-open-in-vscode",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/dsh-open-in-vscode",
+      "category": "notify",
+      "description": {
+        "zh": "从 Web GUI 一键在 VS Code 中打开工作区目录。",
+        "en": "Open DSH workspace directories in VS Code directly from the web GUI."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/dsh-open-in-vscode",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-notification",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/dsh-notification",
+      "category": "notify",
+      "description": {
+        "zh": "回合完成桌面通知，按结果分控 + 关键词过滤。",
+        "en": "Desktop notifications for turn completions, with per-outcome controls and keyword rules."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/dsh-notification",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-acp-for-bitfun",
+      "owner": "bobleer",
+      "url": "https://github.com/bobleer/dsh-acp-for-bitfun",
+      "category": "notify",
+      "description": {
+        "zh": "BitFun 与 DSH 的 ACP 交互对接。",
+        "en": "ACP bridge between BitFun and DSH."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:bobleer/dsh-acp-for-bitfun",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "deepseek-harness-acp",
+      "owner": "openma-ai",
+      "url": "https://github.com/openma-ai/deepseek-harness-acp",
+      "category": "notify",
+      "description": {
+        "zh": "ACP profile 插件与独立 stdio server，可从 Zed 等 ACP 客户端使用完整 DSH agent，并共享 DSH 凭据与会话。",
+        "en": "ACP profile plugin and standalone stdio server for using the full DSH agent from Zed and other ACP clients while sharing DSH credentials and sessions."
+      },
+      "npm": "@openma/deepseek-harness-acp",
+      "install": "dsh plugin --profile web add @openma/deepseek-harness-acp",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "telegram",
+      "owner": "LoserFox",
+      "url": "https://github.com/LoserFox/telegram",
+      "category": "notify",
+      "description": {
+        "zh": "Telegram Bot API 桥接：长轮询、per-chat 会话、HTML 格式化。",
+        "en": "Bridge to the Telegram Bot API: long polling, per-chat sessions, HTML formatting."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:LoserFox/telegram",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-chatnode-wechat",
+      "owner": "Jesse-njx",
+      "url": "https://github.com/Jesse-njx/dsh-chatnode-wechat",
+      "category": "notify",
+      "description": {
+        "zh": "通过 iLink 网关在微信里与 DSH agent 聊天、监控与审批：双向文本、会话切换、进度摘要与编号审批提示。",
+        "en": "Chat with, monitor, and approve your DSH agents from WeChat via the iLink gateway: text both ways, session targeting, digest heartbeats, and numbered approval prompts."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Jesse-njx/dsh-chatnode-wechat",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-session-notification",
+      "owner": "dingyi222666",
+      "url": "https://github.com/dingyi222666/dsh-session-notification",
+      "category": "notify",
+      "description": {
+        "zh": "会话完成等四种状态的通知响应，支持浏览器提示。",
+        "en": "Notifications for four session states, with browser alerts and prompts."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:dingyi222666/dsh-session-notification",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-web-ui-notify",
+      "owner": "bill9109",
+      "url": "https://github.com/bill9109/dsh-web-ui-notify",
+      "category": "notify",
+      "description": {
+        "zh": "桌面通知提醒。",
+        "en": "Desktop notification reminders."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:bill9109/dsh-web-ui-notify",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-webbridge",
+      "owner": "bill9109",
+      "url": "https://github.com/bill9109/dsh-webbridge",
+      "category": "notify",
+      "description": {
+        "zh": "DSH 结合 Kimi WebBridge。",
+        "en": "DSH meets Kimi WebBridge."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:bill9109/dsh-webbridge",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-im-bridge",
+      "owner": "BiBoyang",
+      "url": "https://github.com/BiBoyang/dsh-im-bridge",
+      "category": "notify",
+      "description": {
+        "zh": "微信（iLink）双向桥：turn 完成/批准请求推送、聊天内批准与消息注入、持久去重与长回复收敛分段；通道层为多 IM 预留。",
+        "en": "Two-way WeChat (iLink) bridge: turn-end and approval-request push, in-chat approve/reject and message injection, persistent dedup and convergent long-reply chunking; channel layer extensible to other IMs."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:BiBoyang/dsh-im-bridge",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-lark-bridge",
+      "owner": "imetn",
+      "url": "https://github.com/imetn/dsh-lark-bridge",
+      "category": "notify",
+      "description": {
+        "zh": "DeepSeek Harness 的飞书/Lark 双向控制器，支持 Project 与 Session 路由、交互卡片、审批、附件和任务控制。",
+        "en": "Bidirectional Lark/Feishu controller for DeepSeek Harness with project and session routing, interactive cards, approvals, attachments, and task controls."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:imetn/dsh-lark-bridge",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-feishu-notify",
+      "owner": "dsh-external",
+      "url": "https://github.com/dsh-external/dsh-feishu-notify",
+      "category": "notify",
+      "description": {
+        "zh": "飞书通知（会话结束/等待输入）。",
+        "en": "Feishu notifications on session end / input needed."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:dsh-external/dsh-feishu-notify",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-notify-windows",
+      "owner": "SeverusZh",
+      "url": "https://github.com/SeverusZh/dsh-notify-windows",
+      "category": "notify",
+      "description": {
+        "zh": "Windows 通知，零依赖。",
+        "en": "Windows notifications, zero dependencies."
+      },
+      "npm": "dsh-notify-windows",
+      "install": "dsh plugin --profile web add dsh-notify-windows",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-notify-win",
+      "owner": "Andyqwe44",
+      "url": "https://github.com/Andyqwe44/dsh-notify-win",
+      "category": "notify",
+      "description": {
+        "zh": "原生 Windows toast + 任务栏闪烁，任务完成/审批/提问时触发，支持 Win10/11，npm 安装 `dsh plugin --profile web add dsh-notify-win`。",
+        "en": "Native Windows toast + taskbar flash for task done / approval / ask_user_question, Win10/11, npm install `dsh plugin --profile web add dsh-notify-win`."
+      },
+      "npm": "dsh-notify-win",
+      "install": "dsh plugin --profile web add dsh-notify-win",
+      "added": "2026-08-16"
+    },
+    {
+      "name": "dsh-opencode-server",
+      "owner": "dsh-external",
+      "url": "https://github.com/dsh-external/dsh-opencode-server",
+      "category": "notify",
+      "description": {
+        "zh": "通过 opencode attach 获得丝滑 TUI。",
+        "en": "Smooth TUI via opencode attach."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:dsh-external/dsh-opencode-server",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-island",
+      "owner": "cdxiaodong",
+      "url": "https://github.com/cdxiaodong/dsh-island",
+      "category": "notify",
+      "description": {
+        "zh": "通过 Unix socket 把 DSH agent 的会话、工具调用与审批实时桥接到 CodeIsland macOS 刘海面板，可直接在面板上批准/拒绝。",
+        "en": "Bridge DSH agent sessions, tool calls, and approvals to the CodeIsland macOS notch panel over a Unix socket, with in-panel allow/deny."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:cdxiaodong/dsh-island",
+      "added": "2026-08-16"
+    },
+    {
+      "name": "dsh-bell-notify",
+      "owner": "Laplace-bit",
+      "url": "https://github.com/Laplace-bit/dsh-bell-notify",
+      "category": "notify",
+      "description": {
+        "zh": "生命周期铃声与状态点：为每个环节合成专属提示音（Web Audio，零音频文件），右下角呼吸状态点显示工作状态。",
+        "en": "Lifecycle bells and a status dot: per-event chimes synthesized live with Web Audio (zero audio files), plus a breathing indicator for agent state."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Laplace-bit/dsh-bell-notify",
+      "added": "2026-08-16"
+    },
+    {
+      "name": "llm-adaptive",
+      "owner": "dylan121322",
+      "url": "https://github.com/dylan121322/llm-adaptive",
+      "category": "model",
+      "description": {
+        "zh": "自适应模型路由：请求级复杂度分类，按配置链自动选择后端 provider。",
+        "en": "Adaptive model routing: per-request complexity classification with automatic provider routing."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:dylan121322/llm-adaptive",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-llm-fallbacks",
+      "owner": "btspoony",
+      "url": "https://github.com/btspoony/dsh-llm-fallbacks",
+      "category": "model",
+      "description": {
+        "zh": "基于角色的模型重试与备用策略。",
+        "en": "Role-based LLM retry & fallback strategies."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:btspoony/dsh-llm-fallbacks",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-codex-connect",
+      "owner": "franksong2702",
+      "url": "https://github.com/franksong2702/dsh-codex-connect",
+      "category": "model",
+      "description": {
+        "zh": "通过 ChatGPT OAuth 将 OpenAI Codex 模型接入 DeepSeek Harness，并提供可选的搜索与图片工具。",
+        "en": "Connect ChatGPT OAuth and OpenAI Codex models to DeepSeek Harness, with opt-in search and image tools."
+      },
+      "npm": "dsh-codex-connect",
+      "install": "dsh plugin --profile web add dsh-codex-connect",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-everything-oauth",
+      "owner": "kam74515-boop",
+      "url": "https://github.com/kam74515-boop/dsh-everything-oauth",
+      "category": "model",
+      "description": {
+        "zh": "把本机 Codex / Grok / Claude / OpenCode / CC Switch 登录态导入 DSH，在设置里自选来源并启用模型。",
+        "en": "Import local Codex, Grok, Claude, OpenCode, and CC Switch logins into DSH; pick sources and enable models in Settings."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:kam74515-boop/dsh-everything-oauth",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "Qwen-MM-Plugins",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/Qwen-MM-Plugins",
+      "category": "model",
+      "description": {
+        "zh": "Qwen 多模态插件支持。",
+        "en": "Qwen multi-modal plugin support."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/Qwen-MM-Plugins",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-codex-auth",
+      "owner": "suntianc",
+      "url": "https://github.com/suntianc/dsh-codex-auth",
+      "category": "model",
+      "description": {
+        "zh": "复用 Codex CLI 的 ChatGPT 登录态注册 `openai-codex` LLM 路由，并在 DSH Web 设置中提供 GPT Auth 控件。",
+        "en": "Reuses the Codex CLI ChatGPT login as an `openai-codex` LLM route and adds GPT Auth controls to DSH Web settings."
+      },
+      "npm": "dsh-codex-auth",
+      "install": "dsh plugin --profile web add dsh-codex-auth",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-vision",
+      "owner": "dsh-external",
+      "url": "https://github.com/dsh-external/dsh-vision",
+      "category": "model",
+      "description": {
+        "zh": "视觉桥接：view_image 工具接任意 OpenAI 兼容 VLM。",
+        "en": "Vision bridge: view_image tool over any OpenAI-compatible VLM."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:dsh-external/dsh-vision",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "fabric",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/fabric",
+      "category": "dev",
+      "description": {
+        "zh": "类似 MC Fabric 的 hook 处理器。",
+        "en": "An MC-Fabric-style hook processor."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/fabric",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-harmony",
+      "owner": "CH4ACKO3",
+      "url": "https://github.com/CH4ACKO3/dsh-harmony",
+      "category": "dev",
+      "description": {
+        "zh": "让一个 DSH 插件在运行时修改另一个插件的代码，并提供 Patch 排序、冲突检查和热重载。",
+        "en": "Lets one DSH plugin modify another plugin's code at runtime, with Patch ordering, conflict checks, and hot reload."
+      },
+      "npm": "dsh-harmony",
+      "install": "dsh plugin --profile web add dsh-harmony",
+      "added": "2026-08-15"
+    },
+    {
+      "name": "dsh-git-identity",
+      "owner": "LoserFox",
+      "url": "https://github.com/LoserFox/dsh-git-identity",
+      "category": "dev",
+      "description": {
+        "zh": "git 提交固定使用环境自身作者身份，环境变量注入压过一切 `git config` 设置。",
+        "en": "Pin Git commits to the environment's own author identity; env-var injection overrides all `git config` settings."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:LoserFox/dsh-git-identity",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-context-doctor",
+      "owner": "Zhenyu98",
+      "url": "https://github.com/Zhenyu98/dsh-context-doctor",
+      "category": "dev",
+      "description": {
+        "zh": "上下文注入审计：统计指令链/技能目录/工具 schema 的 token 成本，检测重复与冲突。",
+        "en": "Context injection audit: token costs of instruction chains / skill catalogs / tool schemas, duplicate and conflict detection."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Zhenyu98/dsh-context-doctor",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-plugin-check",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/dsh-plugin-check",
+      "category": "dev",
+      "description": {
+        "zh": "插件健康检查：扫描清单协议/patch 格式/构建陷阱，零依赖只读。",
+        "en": "Plugin health checks: manifest protocol / patch format / build traps, zero-dependency and read-only."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/dsh-plugin-check",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-security-audit",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/dsh-security-audit",
+      "category": "dev",
+      "description": {
+        "zh": "本机安全审计：配置/插件来源/会话/网络暴露面，只读脱敏风险报告。",
+        "en": "Local security audit: config, plugin origins, sessions, network exposure — read-only redacted risk report."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/dsh-security-audit",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-session-health",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/dsh-session-health",
+      "category": "dev",
+      "description": {
+        "zh": "会话文件帧级扫描诊断（torn/损坏/空会话检测）。",
+        "en": "Frame-level scan diagnostics for session files (torn/corrupt/empty detection)."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/dsh-session-health",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-evolve",
+      "owner": "william-jin-cmu",
+      "url": "https://github.com/william-jin-cmu/dsh-evolve",
+      "category": "dev",
+      "description": {
+        "zh": "自进化：agent 在会话内给自己热挂载/卸载持久化插件。",
+        "en": "Self-evolution: the agent hot-mounts/removes persistent plugins on itself mid-session."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:william-jin-cmu/dsh-evolve",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-trace",
+      "owner": "vibeinging",
+      "url": "https://github.com/vibeinging/dsh-trace",
+      "category": "dev",
+      "description": {
+        "zh": "遥测后端：把 turns、model steps、tool calls 导出到 yiTrace。",
+        "en": "Telemetry backend exporting turns, model steps, and tool calls to yiTrace."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:vibeinging/dsh-trace",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-telemetry-redactor",
+      "owner": "030611",
+      "url": "https://github.com/030611/dsh-telemetry-redactor",
+      "category": "dev",
+      "description": {
+        "zh": "在已配置遥测后端接收前，对 `session-telemetry/record` 导出副本中的已支持秘密模式进行脱敏。",
+        "en": "Redacts supported secret patterns from the `session-telemetry/record` export copy before configured telemetry backends receive it."
+      },
+      "npm": "dsh-telemetry-redactor",
+      "install": "dsh plugin --profile web add dsh-telemetry-redactor",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-verification-receipt",
+      "owner": "030611",
+      "url": "https://github.com/030611/dsh-verification-receipt",
+      "category": "dev",
+      "description": {
+        "zh": "把每轮工具计数与粗粒度验证信号写入本地 JSONL，不保存提示词、工具参数或结果正文。",
+        "en": "Writes local JSONL summaries of per-turn tool counts and coarse verification signals without storing prompts, tool arguments, or result text."
+      },
+      "npm": "dsh-verification-receipt",
+      "install": "dsh plugin --profile web add dsh-verification-receipt",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "sandbox-micro",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/sandbox-micro",
+      "category": "dev",
+      "description": {
+        "zh": "microsandbox 沙箱支持。",
+        "en": "Support for the microsandbox backend."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/sandbox-micro",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "sandbox-mxc",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/sandbox-mxc",
+      "category": "dev",
+      "description": {
+        "zh": "微软跨平台沙盒支持。",
+        "en": "Microsoft cross-platform sandbox support."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/sandbox-mxc",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "sandbox-nono",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/sandbox-nono",
+      "category": "dev",
+      "description": {
+        "zh": "nono 沙盒支持。",
+        "en": "Support for the nono sandbox backend."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/sandbox-nono",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-agent-budget",
+      "owner": "vibeinging",
+      "url": "https://github.com/vibeinging/dsh-agent-budget",
+      "category": "dev",
+      "description": {
+        "zh": "agent 树 token 预算管理。",
+        "en": "Agent-tree token budget management."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:vibeinging/dsh-agent-budget",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-polyglot",
+      "owner": "Jesse-njx",
+      "url": "https://github.com/Jesse-njx/dsh-polyglot",
+      "category": "dev",
+      "description": {
+        "zh": "DSH 的模型切换器：指向任意 OpenAI 兼容端点，内置精选免费/低价 DeepSeek 服务商预设，免费额度限流时自动回退。",
+        "en": "The model switch for DSH: point it at any OpenAI-compatible endpoint, with curated free/cheap DeepSeek provider presets and automatic fallback when a free tier rate-limits you."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Jesse-njx/dsh-polyglot",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-tool-approval",
+      "owner": "ilharp",
+      "url": "https://github.com/ilharp/dsh-tool-approval",
+      "category": "dev",
+      "description": {
+        "zh": "手动审批模式（Manual/Ask Mode）。",
+        "en": "Manual approval mode (\"Manual Mode\" / \"Ask Mode\")."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:ilharp/dsh-tool-approval",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-turn-approval",
+      "owner": "arrow949",
+      "url": "https://github.com/arrow949/dsh-turn-approval",
+      "category": "dev",
+      "description": {
+        "zh": "DSH「允许本次任务」临时授权：仅在当前任务内自动放行同类 `danger-full-access` 请求，任务结束自动失效。",
+        "en": "Turn-scoped “Allow for this task” approvals: automatically allow matching `danger-full-access` escalations only for the current task, then expire."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:arrow949/dsh-turn-approval",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "plugin-template",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/plugin-template",
+      "category": "dev",
+      "description": {
+        "zh": "插件模板仓库（基于 turtle-ui 官方仓库）。",
+        "en": "Plugin template repo (based on the official turtle-ui repo)."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/plugin-template",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-tps",
+      "owner": "Small-tailqwq",
+      "url": "https://github.com/Small-tailqwq/dsh-tps",
+      "category": "dev",
+      "description": {
+        "zh": "TPS 指标插件。",
+        "en": "A TPS metrics plugin."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Small-tailqwq/dsh-tps",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-tool-call-stats",
+      "owner": "disyli",
+      "url": "https://github.com/disyli/dsh-tool-call-stats",
+      "category": "dev",
+      "description": {
+        "zh": "进程内工具调用统计：提供 `tool_stats` 工具，按工具汇报调用次数、失败次数与平均耗时。",
+        "en": "Per-process tool-call statistics: a `tool_stats` tool reporting per-tool call counts, error counts, and average durations."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:disyli/dsh-tool-call-stats",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-fail-logger",
+      "owner": "Areium",
+      "url": "https://github.com/Areium/dsh-fail-logger",
+      "category": "dev",
+      "description": {
+        "zh": "全模式调用工具失败自动实录：把原生工具 / PTC run_code / 代码内嵌工具调用的失败错因去重计数后写入 skill，越用越少错。",
+        "en": "Auto-log failed tool calls across native tools, PTC run_code, and inline invocations: dedup and count root causes into a skill so repeated mistakes fade."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Areium/dsh-fail-logger",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-eval-harness",
+      "owner": "BiBoyang",
+      "url": "https://github.com/BiBoyang/dsh-eval-harness",
+      "category": "dev",
+      "description": {
+        "zh": "DSH 插件评测框架：YAML 用例驱动真实 headless agent，断言工具调用/参数/返回与 token 用量，baseline 门禁做 CI 回归。",
+        "en": "Evaluation harness for DSH plugins: YAML cases drive real headless agent runs, assert on tool calls, args, results and token usage, with a baseline gate for CI regression."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:BiBoyang/dsh-eval-harness",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "oh-dsh",
+      "owner": "hust-open-atom-club",
+      "url": "https://github.com/hust-open-atom-club/oh-dsh",
+      "category": "dev",
+      "description": {
+        "zh": "社区发行版：TUI、桌面端与 Web UI 统一体验，分层安装、一步到位。",
+        "en": "Community distribution: TUI, desktop, and Web UI as one bundle with layered installation."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:hust-open-atom-club/oh-dsh",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-annotate",
+      "owner": "BrambleXu",
+      "url": "https://github.com/BrambleXu/dsh-annotate",
+      "category": "dev",
+      "description": {
+        "zh": "面向 Vibe Coding 的浏览器元素标注插件：直接选取页面元素，并将结构化视觉反馈发送给 DeepSeek Harness Agent。",
+        "en": "Select browser elements directly during Vibe Coding and send structured visual feedback to the DeepSeek Harness Agent."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:BrambleXu/dsh-annotate",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-prompt-profile",
+      "owner": "BrambleXu",
+      "url": "https://github.com/BrambleXu/dsh-prompt-profile",
+      "category": "dev",
+      "description": {
+        "zh": "DeepSeek Harness 可复用 Markdown Prompt Profile，支持单轮模型选择、参数替换和状态恢复。",
+        "en": "Reusable Markdown prompt profiles for DeepSeek Harness with per-turn model selection, argument substitution, and state restoration."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:BrambleXu/dsh-prompt-profile",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-revdiff",
+      "owner": "BrambleXu",
+      "url": "https://github.com/BrambleXu/dsh-revdiff",
+      "category": "dev",
+      "description": {
+        "zh": "DeepSeek Harness 原生交互式 Git diff 审查，支持结构化批注并回传当前 Agent 会话。",
+        "en": "Native interactive Git diff review for DeepSeek Harness with structured annotations sent back to the current Agent session."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:BrambleXu/dsh-revdiff",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-gitflow",
+      "owner": "lonelymoon87",
+      "url": "https://github.com/lonelymoon87/dsh-gitflow",
+      "category": "dev",
+      "description": {
+        "zh": "增加需要审批的 Git 状态、diff、日志、提交、分支和可选检查点工具。",
+        "en": "Adds approval-gated Git status, diff, log, commit, branch, and optional checkpoint tools."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:lonelymoon87/dsh-gitflow",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-guardian",
+      "owner": "lonelymoon87",
+      "url": "https://github.com/lonelymoon87/dsh-guardian",
+      "category": "dev",
+      "description": {
+        "zh": "增加危险操作策略检查、输出脱敏和安全审查工作流。",
+        "en": "Adds dangerous-operation policy checks, output redaction, and a security-review workflow."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:lonelymoon87/dsh-guardian",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-plugin-manager",
+      "owner": "Jesse-njx",
+      "url": "https://github.com/Jesse-njx/dsh-plugin-manager",
+      "category": "dev",
+      "description": {
+        "zh": "`dsh pm` 插件管理器：多源搜索（awesome 列表 + GitHub + npm）、按 profile 安装/移除/更新，以及 doctor 审计（清单、bundle patch、版本漂移）。",
+        "en": "The `dsh pm` plugin manager: multi-source search (awesome list + GitHub + npm), install/remove/update per profile, and a doctor audit of manifests, bundle patches, and version drift."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Jesse-njx/dsh-plugin-manager",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-tmuxctl",
+      "owner": "Jesse-njx",
+      "url": "https://github.com/Jesse-njx/dsh-tmuxctl",
+      "category": "dev",
+      "description": {
+        "zh": "掌控你的 tmux 面板：list/send-keys/capture、在面板中运行长任务并 watch，破坏性命令需审批。",
+        "en": "Take control of your tmux panes: list/send-keys/capture, run long jobs in a pane with watch mode, and approval-gated destructive commands."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Jesse-njx/dsh-tmuxctl",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-updater-ui",
+      "owner": "xingyingyuzhui",
+      "url": "https://github.com/xingyingyuzhui/dsh-updater-ui",
+      "category": "dev",
+      "description": {
+        "zh": "设置页中的 DSH 自助更新器：一键检查/拉取（git pull --ff-only）、自动后台检查、版本对比与更新说明预览，带红点提醒。",
+        "en": "DSH self-updater in the settings page: one-click check/pull (`git pull --ff-only`), auto background checks, version diff and changelog preview with a red-dot reminder."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:xingyingyuzhui/dsh-updater-ui",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-repro",
+      "owner": "EvilIrving",
+      "url": "https://github.com/EvilIrving/dsh-repro",
+      "category": "dev",
+      "description": {
+        "zh": "/repro 导出最小可复现问题包：去 secret 的会话日志、失败命令与 git diff。",
+        "en": "/repro exports a minimal, secret-scrubbed, replayable problem bundle: the session log, failed commands, and Git diff."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:EvilIrving/dsh-repro",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-mcp-panel",
+      "owner": "PerryLink",
+      "url": "https://github.com/PerryLink/dsh-mcp-panel",
+      "category": "dev",
+      "description": {
+        "zh": "官方 MCP 客户端（dsh-mcp-client）的只读运行时管理面板：/mcp 命令与设置页 MCP 页签展示连接状态、已注册工具、错误与重连计数，脱敏展示并提供启停 patch 建议。",
+        "en": "Read-only runtime management panel for the official DSH MCP client: connection status, registered tools, errors, and reconnect counts through the /mcp command and a Settings tab, with sanitized display and enable/disable patch suggestions."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:PerryLink/dsh-mcp-panel",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-pain-point-check",
+      "owner": "ICCuse",
+      "url": "https://github.com/ICCuse/dsh-pain-point-check",
+      "category": "dev",
+      "description": {
+        "zh": "强制痛点检查：同一问题连续 2 个实验未收敛后注入三问、拦截非调查类工具调用直到答出、阻止同方向重试。",
+        "en": "Enforced pain-point gate: after two non-converged experiments it injects the three questions, denies non-investigative tool calls until answered, and blocks same-direction retries."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:ICCuse/dsh-pain-point-check",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "forkprobe",
+      "owner": "Jayden-X-L",
+      "url": "https://github.com/Jayden-X-L/forkprobe",
+      "category": "dev",
+      "description": {
+        "zh": "同一任务并行试跑多个技能，对比结果选出最优。",
+        "en": "Compare multiple skills on the same task and pick the winner."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Jayden-X-L/forkprobe",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "plugin-registry",
+      "owner": "vlln",
+      "url": "https://github.com/vlln/plugin-registry",
+      "category": "dev",
+      "description": {
+        "zh": "插件生态基建：浏览器面板管理官方 repository 插件（0 patch）+ make-dsh-plugin 插件开发引导技能。",
+        "en": "Ecosystem infrastructure: a thin browser console for managing official repository plugins (zero patches) plus a make-dsh-plugin skill for guided plugin development."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:vlln/plugin-registry",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-multica-runtime",
+      "owner": "forrestchang",
+      "url": "https://github.com/forrestchang/dsh-multica-runtime",
+      "category": "dev",
+      "description": {
+        "zh": "让 dsh 运行时跑在 Multica 上。",
+        "en": "Run the dsh runtime on Multica."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:forrestchang/dsh-multica-runtime",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-user-experience",
+      "owner": "DietCokewithSugar",
+      "url": "https://github.com/DietCokewithSugar/dsh-user-experience",
+      "category": "dev",
+      "description": {
+        "zh": "帮你发现项目中可能存在的用户体验问题：自动走查 React/TypeScript 源码，定位问题并给出具体优化建议。",
+        "en": "Finds potential UX issues in your project: automatically reviews React/TypeScript code, pinpoints each problem, and gives concrete suggestions."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:DietCokewithSugar/dsh-user-experience",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-cost-tracker",
+      "owner": "yflmq001",
+      "url": "https://github.com/yflmq001/dsh-cost-tracker",
+      "category": "dev",
+      "description": {
+        "zh": "按模型追踪 token 成本：可配置缓存命中/未命中、输出与高峰时段单价，实时会话花费条，并标记未配置价格的模型。",
+        "en": "Per-model token cost tracking with configurable cache-hit/miss, output and peak-window pricing, a live session cost bar, and unconfigured-model flags."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:yflmq001/dsh-cost-tracker",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-passwords",
+      "owner": "slywalker2006",
+      "url": "https://github.com/slywalker2006/dsh-passwords",
+      "category": "dev",
+      "description": {
+        "zh": "DSH Web UI 登录网关：首次配置、bcrypt + 静态加密（AES-256-GCM/HMAC）、防爆破、审计日志、TLS 1.2+ 与 80→443 跳转、CSRF 与防嵌框。",
+        "en": "Login gateway for the DSH web UI: password door with first-run setup, bcrypt + at-rest encryption (AES-256-GCM/HMAC), brute-force lockout, audit log, TLS 1.2+ with 80→443 redirect, CSRF, anti-framing."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:slywalker2006/dsh-passwords",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-webui-auth",
+      "owner": "Yuuz12",
+      "url": "https://github.com/Yuuz12/dsh-webui-auth",
+      "category": "dev",
+      "description": {
+        "zh": "WebUI 身份认证：HTTP/传输层强制登录（资源、插件 bundle、/api、WebSocket 四层防护），服务端会话 + HttpOnly Cookie。",
+        "en": "WebUI authentication enforced at the HTTP/transport layer: four-layer login gate (resources, plugin bundles, /api, WebSocket), server-side sessions with HttpOnly cookies."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Yuuz12/dsh-webui-auth",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-lan-access",
+      "owner": "Leon0555",
+      "url": "https://github.com/Leon0555/dsh-lan-access",
+      "category": "dev",
+      "description": {
+        "zh": "局域网访问：Web GUI 绑定 0.0.0.0 + crypto.randomUUID polyfill（修复非安全上下文下 RPC 崩溃）。",
+        "en": "LAN access for the Web GUI: 0.0.0.0 bind plus a crypto.randomUUID polyfill for non-secure (LAN HTTP) contexts."
+      },
+      "npm": "dsh-lan-access",
+      "install": "dsh plugin --profile web add dsh-lan-access",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh4vscode",
+      "owner": "DoggyHU",
+      "url": "https://github.com/DoggyHU/dsh4vscode",
+      "category": "dev",
+      "description": {
+        "zh": "基于 DSH agent 的 VS Code 聊天窗口，模型自动路由。",
+        "en": "VS Code chat windows backed by the DSH agent with model auto-routing."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:DoggyHU/dsh4vscode",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-desktop",
+      "owner": "foolgry",
+      "url": "https://github.com/foolgry/dsh-desktop",
+      "category": "dev",
+      "description": {
+        "zh": "开箱即用的 Electron 桌面版，自动跟随上游发版。",
+        "en": "Download-and-run Electron desktop build that tracks upstream releases automatically."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:foolgry/dsh-desktop",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "deepseek-harness-action",
+      "owner": "Lixiaoyiao",
+      "url": "https://github.com/Lixiaoyiao/deepseek-harness-action",
+      "category": "dev",
+      "description": {
+        "zh": "GitHub Action 运行 DSH 做 PR 审查、CI 诊断与受信任修复。",
+        "en": "GitHub Action running DSH for PR review, CI diagnosis and trusted fixes."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Lixiaoyiao/deepseek-harness-action",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-test-runner",
+      "owner": "suimi8",
+      "url": "https://github.com/suimi8/dsh-test-runner",
+      "category": "dev",
+      "description": {
+        "zh": "结构化测试运行工具：自动识别 Vitest/Jest/pytest/node:test 并解析失败。",
+        "en": "Structured test runner tool: auto-detects Vitest/Jest/pytest/node:test and parses failures."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:suimi8/dsh-test-runner",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-review-loop",
+      "owner": "wuxiangru915",
+      "url": "https://github.com/wuxiangru915/dsh-review-loop",
+      "category": "dev",
+      "description": {
+        "zh": "增量 diff 审查器：Web 审查面板 + 审查意见注入 agent。",
+        "en": "Incremental diff reviewer with a Web UI panel and feedback injection into the agent."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:wuxiangru915/dsh-review-loop",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-mcp-manager",
+      "owner": "hyqhyq3",
+      "url": "https://github.com/hyqhyq3/dsh-mcp-manager",
+      "category": "dev",
+      "description": {
+        "zh": "MCP 服务器管理器：OAuth 或静态 token 认证 + 设置页。",
+        "en": "MCP server manager with OAuth or static-token auth and a Settings page."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:hyqhyq3/dsh-mcp-manager",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-doctor",
+      "owner": "asdf17128",
+      "url": "https://github.com/asdf17128/dsh-doctor",
+      "category": "dev",
+      "description": {
+        "zh": "Profile 体检：检出 patch 丢失字段、不存在的 entry id 与工具重名冲突。",
+        "en": "Profile health check: finds config fields dropped by patch, missing entry ids, and tool-name collisions."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:asdf17128/dsh-doctor",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-plugin-manager-registry",
+      "owner": "Jesse-njx",
+      "url": "https://github.com/Jesse-njx/dsh-plugin-manager-registry",
+      "category": "dev",
+      "description": {
+        "zh": "离线容错的插件注册表，聚合并去重各类来源的 DSH 插件。",
+        "en": "Offline-tolerant registry that discovers and deduplicates DSH plugins from lists, topics and npm."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Jesse-njx/dsh-plugin-manager-registry",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-session-cleaner",
+      "owner": "fountunt",
+      "url": "https://github.com/fountunt/dsh-session-cleaner",
+      "category": "dev",
+      "description": {
+        "zh": "无需重启即可删除运行中 Web 运行时里的会话。",
+        "en": "Delete sessions from a running web runtime without a restart."
+      },
+      "npm": "dsh-session-cleaner",
+      "install": "dsh plugin --profile web add dsh-session-cleaner",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-portable-launcher",
+      "owner": "15828148",
+      "url": "https://github.com/15828148/dsh-portable-launcher",
+      "category": "dev",
+      "description": {
+        "zh": "Windows 一键便携启动器，国内镜像回退。",
+        "en": "One-click portable Windows launcher with CN mirror fallback."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:15828148/dsh-portable-launcher",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-guardian",
+      "owner": "cdxiaodong",
+      "url": "https://github.com/cdxiaodong/dsh-guardian",
+      "category": "dev",
+      "description": {
+        "zh": "Agent 安全护栏：拦截并审计所有工具调用，命中敏感操作就要求人工确认。",
+        "en": "Agent security guardrail: intercepts and audits every tool call, requiring human confirmation on sensitive operations."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:cdxiaodong/dsh-guardian",
+      "added": "2026-08-16"
+    },
+    {
+      "name": "dsh-ads",
+      "owner": "Nagi-ovo",
+      "url": "https://github.com/Nagi-ovo/dsh-ads",
+      "category": "fun",
+      "description": {
+        "zh": "2005 年中文站点风格的整活广告插件：侧栏广告/信息流/角落弹窗 + 假关闭叉，素材全虚构。",
+        "en": "Parody ads in 2005-Chinese-web style: sidebar banners, in-chat feeds, corner popups, and a close button whose hit area is smaller than it looks. All fictional."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Nagi-ovo/dsh-ads",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-gomoku",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/dsh-gomoku",
+      "category": "fun",
+      "description": {
+        "zh": "与 AI 下五子棋，也可让 AI 对局比棋力。",
+        "en": "Play Gomoku against the AI, or let two AIs battle it out."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/dsh-gomoku",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-stock-market",
+      "owner": "AnacondaKC",
+      "url": "https://github.com/AnacondaKC/dsh-stock-market",
+      "category": "fun",
+      "description": {
+        "zh": "有效解决了写代码的时候账户不能同时亏钱的 BUG。",
+        "en": "Fixes the bug where your account can't lose money while you code."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:AnacondaKC/dsh-stock-market",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-emoji",
+      "owner": "hellodigua",
+      "url": "https://github.com/hellodigua/dsh-emoji",
+      "category": "fun",
+      "description": {
+        "zh": "为 AI 回复自动添加表情。",
+        "en": "Automatically add emojis to AI replies."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:hellodigua/dsh-emoji",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-minigames",
+      "owner": "lhh010",
+      "url": "https://github.com/lhh010/dsh-minigames",
+      "category": "fun",
+      "description": {
+        "zh": "右侧小游戏面板：18 款离线小游戏，等模型回复时的摸鱼神器。",
+        "en": "Side-panel arcade: 18 offline mini-games to play while the model thinks."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:lhh010/dsh-minigames",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-stickers",
+      "owner": "william-jin-cmu",
+      "url": "https://github.com/william-jin-cmu/dsh-stickers",
+      "category": "fun",
+      "description": {
+        "zh": "用户与 agent 双向表情贴纸互动。",
+        "en": "Bidirectional sticker reactions between user and agent."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:william-jin-cmu/dsh-stickers",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "whale-girl",
+      "owner": "vlln",
+      "url": "https://github.com/vlln/whale-girl",
+      "category": "fun",
+      "description": {
+        "zh": "桌面宠物（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍。",
+        "en": "Desktop pet (QQ-pet style): floats in the corner, draggable, feedable, playable."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:vlln/whale-girl",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "deepseek-manners",
+      "owner": "Moeblack",
+      "url": "https://github.com/Moeblack/deepseek-manners",
+      "category": "fun",
+      "description": {
+        "zh": "给每次消息后注入感谢语，做个有礼貌的人。",
+        "en": "Append a thank-you note after every message. Mind your manners."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:Moeblack/deepseek-manners",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-plugin-d399",
+      "owner": "HuanLinOTO",
+      "url": "https://github.com/HuanLinOTO/dsh-plugin-d399",
+      "category": "fun",
+      "description": {
+        "zh": "模型生成时弹出小游戏菜单（wordle/消消乐，可扩展）。",
+        "en": "Pops up a mini-game menu (wordle, match-3, extensible) while the model generates."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:HuanLinOTO/dsh-plugin-d399",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-auto-chess",
+      "owner": "omdsh-dev",
+      "url": "https://github.com/omdsh-dev/dsh-auto-chess",
+      "category": "fun",
+      "description": {
+        "zh": "自走棋：人机对战或双 AI 对弈。",
+        "en": "Auto chess: human vs AI, or AI vs AI."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:omdsh-dev/dsh-auto-chess",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "dsh-douyin",
+      "owner": "AnacondaKC",
+      "url": "https://github.com/AnacondaKC/dsh-douyin",
+      "category": "fun",
+      "description": {
+        "zh": "侧栏短视频：原生播放器、系列导航、精确历史回放。",
+        "en": "Short-video sidebar: native player, series navigation, precise history replay."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:AnacondaKC/dsh-douyin",
+      "added": "2026-08-13"
+    },
+    {
+      "name": "DeepSeek-Harness-Pet",
+      "owner": "minybear",
+      "url": "https://github.com/minybear/DeepSeek-Harness-Pet",
+      "category": "fun",
+      "description": {
+        "zh": "Codex 风格桌面宠物：右下角悬浮动画精灵，随 agent 运行状态实时变化（工作、等待、报错、完成）。",
+        "en": "Codex-style desktop pet: a floating animated sprite in the corner that mirrors the agent's running state (working, waiting, failed, done)."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:minybear/DeepSeek-Harness-Pet",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-web-search-pro",
+      "owner": "anweat",
+      "url": "https://github.com/anweat/dsh-web-search-pro",
+      "category": "fun",
+      "description": {
+        "zh": "增强型、可持久化的网页搜索：多引擎路由（DeepSeek/Exa/DDG/Bing/Jina + GitHub/B站/YouTube/V2EX/小红书/Twitter/Reddit/RSS）、SQLite+LRU 缓存、userscript 风格抽取、Playwright 渲染。",
+        "en": "Persistent enhanced web search: multi-engine routing (DeepSeek/Exa/DDG/Bing/Jina + GitHub/Bilibili/YouTube/V2EX/Xiaohongshu/Twitter/Reddit/RSS), SQLite+LRU cache, userscript-style extraction, Playwright rendering."
+      },
+      "npm": "dsh-web-search-pro",
+      "install": "dsh plugin --profile web add dsh-web-search-pro",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-browser",
+      "owner": "anweat",
+      "url": "https://github.com/anweat/dsh-browser",
+      "category": "fun",
+      "description": {
+        "zh": "自包含浏览器运行时：Playwright（chromium）+ OpenCLI 作为插件本地依赖（全局复用回退），提供 `browser` 服务与 9 个交互式浏览器工具。",
+        "en": "Self-contained browser runtime: Playwright (chromium) + OpenCLI as plugin-local dependencies (global reuse fallback), exposes a `browser` service and 9 interactive browser tools."
+      },
+      "npm": "@anweat/dsh-browser",
+      "install": "dsh plugin --profile web add @anweat/dsh-browser",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-voice-webspeech",
+      "owner": "anweat",
+      "url": "https://github.com/anweat/dsh-voice-webspeech",
+      "category": "fun",
+      "description": {
+        "zh": "浏览器 Web Speech API 语音输入：零服务端、零密钥、零模型下载（Edge=Azure 语音、Chrome=Google 语音）。",
+        "en": "Browser Web Speech API voice input: zero server, zero keys, zero model downloads (Edge=Azure, Chrome=Google speech)."
+      },
+      "npm": "dsh-voice-webspeech",
+      "install": "dsh plugin --profile web add dsh-voice-webspeech",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-restart",
+      "owner": "anweat",
+      "url": "https://github.com/anweat/dsh-restart",
+      "category": "fun",
+      "description": {
+        "zh": "DSH 重启插件：可配置的重启方式（Node 原生/旧 PowerShell 适配）、重启后自动继续的提示词、可选看门狗自动拉起。",
+        "en": "Restart DSH: configurable restart method (Node native / legacy PowerShell), post-restart continue prompt, optional watchdog auto-relaunch."
+      },
+      "npm": "dsh-restart",
+      "install": "dsh plugin --profile web add dsh-restart",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-pet",
+      "owner": "FlytoMAYDAY80",
+      "url": "https://github.com/FlytoMAYDAY80/dsh-pet",
+      "category": "fun",
+      "description": {
+        "zh": "桌面小鲸鱼，实时感知会话状态。",
+        "en": "Desktop whale pet with live session state."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:FlytoMAYDAY80/dsh-pet",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-weather",
+      "owner": "sunshine-lang",
+      "url": "https://github.com/sunshine-lang/dsh-weather",
+      "category": "fun",
+      "description": {
+        "zh": "天气工具：Open-Meteo 数据（免费，无需 API key）。",
+        "en": "Weather tool via Open-Meteo (free, no API key)."
+      },
+      "npm": "dsh-weather",
+      "install": "dsh plugin --profile web add dsh-weather",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-pdf",
+      "owner": "sunshine-lang",
+      "url": "https://github.com/sunshine-lang/dsh-pdf",
+      "category": "fun",
+      "description": {
+        "zh": "PDF 工具箱：基于 pdfjs-dist 提取文本、元数据与页码范围。",
+        "en": "PDF toolbox: extract text, metadata and page ranges via pdfjs-dist."
+      },
+      "npm": "dsh-pdf",
+      "install": "dsh plugin --profile web add dsh-pdf",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-ui-whale",
+      "owner": "dsh-external",
+      "url": "https://github.com/dsh-external/dsh-ui-whale",
+      "category": "fun",
+      "description": {
+        "zh": "像素鲸鱼伙伴（眨眼/摆尾/喷水/爱心）。",
+        "en": "Pixel whale companion that blinks, wags its tail and spouts hearts."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:dsh-external/dsh-ui-whale",
+      "added": "2026-08-14"
+    },
+    {
+      "name": "dsh-whale-galgame",
+      "owner": "JAdpp",
+      "url": "https://github.com/JAdpp/dsh-whale-galgame",
+      "category": "fun",
+      "description": {
+        "zh": "多角色 Galgame 对话界面：角色与回复模型可独立切换，分角色保存好感度、记忆、对话历史与 CG 图鉴，并根据 Harness 跨会话任务事件做出角色回应。",
+        "en": "Multi-character Galgame conversation view with separate character and reply-model selection, per-character affection, memory, dialogue history, and CG galleries, plus responses informed by task events across Harness sessions."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:JAdpp/dsh-whale-galgame",
+      "added": "2026-08-16"
+    },
+    {
+      "name": "dsh-unarchive",
+      "owner": "edfrey0044",
+      "url": "https://github.com/edfrey0044/dsh-unarchive",
+      "category": "session",
+      "description": {
+        "zh": "恢复已归档会话：/unarchive 命令与 unarchive_session 工具，把会话移出归档集合、在原位置重新出现在工作区（归档从不删除数据）。",
+        "en": "Restore archived sessions: a /unarchive command and an unarchive_session tool that remove sessions from the archive set so they reappear in the workspace at their original position (archiving never deletes data)."
+      },
+      "npm": null,
+      "install": "dsh plugin --profile web add github:edfrey0044/dsh-unarchive",
+      "added": "2026-08-16"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Adds [edfrey0044/dsh-unarchive](https://github.com/edfrey0044/dsh-unarchive) — a DeepSeek Harness plugin that restores archived sessions.

Archiving hides a session from every grouping surface (workspace groups, Ungrouped, flat list, search) but never deletes it. This plugin adds the missing inverse via two entry points:

- **`/unarchive` command** (GUI command palette) — no argument lists archived sessions with best-effort titles; a session id restores it.
- **`unarchive_session` tool** — the agent can list or restore archived sessions from any conversation.

Both write through the durable core API `workspaceRegistry.unarchiveSession`, so every connected GUI client updates live (`host/archived-sessions-changed`) and the change survives restarts. Session logs and workspace accounting slots are never touched.

![demo](https://raw.githubusercontent.com/edfrey0044/dsh-unarchive/main/assets/demo.png)

## Checklist

- [x] Repo tagged with the `dsh-plugin` topic
- [x] `docs/plugins.json` entry added, `count` 313 → 314
- [x] `README.md` (zh) and `README.en.md` (en) lines added under **Tools & Capabilities**

## Install

```
dsh plugin --profile web add github:edfrey0044/dsh-unarchive
```