### PR TITLE
Add daetz-coder/dsh-multi-chat: multi-window wall for DSH Web UI

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -57,6 +57,7 @@ DeepSeek Harness is DeepSeek's open-source agent harness — a runnable coding a
 
 ### UI Enhancements
 
+- [daetz-coder/dsh-multi-chat](https://github.com/daetz-coder/dsh-multi-chat) - A multi-window wall for the DSH Web UI: run and monitor N conversations side-by-side in one screen, with auto-discovery, per-window controls, and an authenticated LAN gateway for phone/tablet access.
 - [pk7j7sqryy-ops/dsh-token-pet](https://github.com/pk7j7sqryy-ops/dsh-token-pet) - Cute token-usage widget in the session header: context occupancy, session usage and breakdown, plus date/weekday, weather, 3-day forecast and severe-weather alerts.
 
 - [Zhangbo-cn/dsh-voice-input-plugin](https://github.com/Zhangbo-cn/dsh-voice-input-plugin) - Composer microphone: click for continuous monitoring or hold to talk; browser speech recognition types words into the composer as you speak, while replies are read aloud as they stream via host Edge TTS (sentence-split), pausing recognition while reading to avoid echo, click to stop.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 ## 插件
 
 ### 🎨 UI 增强
+- [daetz-coder/dsh-multi-chat](https://github.com/daetz-coder/dsh-multi-chat) — 在 DSH Web 界面里并排运行、监控多个对话实例的插件：多窗口墙 + 自动发现 + 单窗控制，内置带口令认证的局域网网关，手机/平板也能看。
 - [pk7j7sqryy-ops/dsh-token-pet](https://github.com/pk7j7sqryy-ops/dsh-token-pet) — 会话头部卡通用量小部件：布布玩偶 + 上下文占用/会话累计/构成，附日期周几、天气、3 天预报与极端天气预警（雨滴/雪花动画），跟随主题色。
 
 - [zealot00/dsh-pet](https://github.com/zealot00/dsh-pet) — DSH Web UI 桌面宠物：精灵图动画、agent 状态联动、拖拽、闹钟（每天/一次）与番茄钟，皮肤下拉选择 + 预览。


### PR DESCRIPTION
Adds **daetz-coder/dsh-multi-chat** to the UI Enhancements / UI 增强 category.

A multi-window wall plugin for the official DeepSeek Harness Web UI: run and monitor N DSH conversation instances side-by-side in one screen — with port auto-discovery, per-window controls (maximize/refresh/new-tab/remove), and a built-in token-authenticated LAN gateway for phone/tablet access.

Checklist:
- [x] Declares `dsh.bundle` manifest (`dsh.bundle.patch` → `./cordis.patch.yml`) — installable via `dsh plugin add`
- [x] Has `dsh-plugin` topic
- [x] Real working code
- [x] Both README.en.md and README.md updated (one line each)
- [x] Published to npm (dsh-multi-chat) — prebuilt install