### PR TITLE
Add chenproton/dsh-history plugin (Sessions & Messages)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -161,6 +161,7 @@ DeepSeek Harness is DeepSeek's open-source agent harness — a runnable coding a
 
 
 - [edfrey0044/dsh-unarchive](https://github.com/edfrey0044/dsh-unarchive) - Restore archived sessions: a /unarchive command and an unarchive_session tool that remove sessions from the archive set so they reappear in the workspace at their original position (archiving never deletes data).
+- [chenproton/dsh-history](https://github.com/chenproton/dsh-history) - Browse every message you sent in the current session: full-history listing with newest-first sort, text filter, one-click copy, and click-to-jump that auto-loads earlier history when the target is not yet loaded.
 
 ### Memory
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 
 
 - [edfrey0044/dsh-unarchive](https://github.com/edfrey0044/dsh-unarchive) — 恢复已归档会话：/unarchive 命令与 unarchive_session 工具，把会话移出归档集合、在原位置重新出现在工作区（归档从不删除数据）。
+- [chenproton/dsh-history](https://github.com/chenproton/dsh-history) — 会话历史消息查看：列出当前会话全部你发送的消息，支持排序、搜索、一键复制与点击跳转定位（目标未加载时自动加载更早历史）。
 
 ### 🧠 记忆
 


### PR DESCRIPTION
Adds [chenproton/dsh-history](https://github.com/chenproton/dsh-history) to the Sessions & Messages section.

The plugin lists every user-sent message in the current conversation (full history, including pages not yet loaded), with newest-first sort toggle, text filter, one-click copy, and click-to-jump that auto-loads earlier history when the target is outside the loaded window.

- `dsh.bundle` manifest declared (cordis.patch.yml)
- `dsh-plugin` topic added
- entries added to both README.md (中文) and README.en.md