### PR TITLE
Add dsh-verify — independent browser acceptance testing for agent deliverables

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -280,6 +280,7 @@ DeepSeek Harness is DeepSeek's open-source agent harness — a runnable coding a
 - [siweina/dsh-novel-writer](https://github.com/siweina/dsh-novel-writer) — Novel writing assistant: chapter library, sentence-pattern analysis (9 categories / emotion curve / style fingerprint), style check, plot tracking, batch import and continuation writing, with per-tool Web UI toggles.
 - [moon09300731/dsh-vision-tools](https://github.com/moon09300731/dsh-vision-tools) — Full vision-capability bundle for DeepSeek Harness: a `vision_understand` tool (OpenAI-compatible vision APIs, free Zhipu GLM-4V-Flash by default) plus paste/drag-and-drop/button entry points for image recognition.
 - [moon09300731/dsh-approval-gate](https://github.com/moon09300731/dsh-approval-gate) — Risk-gated approval automation: flash pre-classifies whether a write/command is irreversible — safe operations are auto-approved, dangerous ones are escalated to human approval (fail-safe).
+- [dsh-verify](https://github.com/263311487-ux/dsh-verify) — Independent browser acceptance testing for agent deliverables: JSON spec drives real headless Chromium, asserts computed styles and pixel diffs, returns an HTML report and 0/1 exit code; ships npm CLI, GitHub Action, and MCP server.
 ### Skills
 
 - [gongyijie85/dsh-ponytail](https://github.com/gongyijie85/dsh-ponytail) - Ponytail, lazy senior dev mode, for DSH: 6 skills (ponytail, ponytail-audit, ponytail-debt, ponytail-gain, ponytail-help, ponytail-review) adapted from DietrichGebert/ponytail (MIT).

--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [siweina/dsh-novel-writer](https://github.com/siweina/dsh-novel-writer) — 小说写作助手：章节库管理、句式模式分析（九类句式/情感曲线/风格指纹）、风格自检、伏笔登记、批量导入与续写辅助，带 Web UI 开关。
 - [moon09300731/dsh-vision-tools](https://github.com/moon09300731/dsh-vision-tools) — DeepSeek Harness 视觉能力全家桶：vision_understand 工具（OpenAI 兼容视觉 API，默认免费智谱 GLM-4V-Flash）+ 粘贴/拖拽/按钮三入口识图。
 - [moon09300731/dsh-approval-gate](https://github.com/moon09300731/dsh-approval-gate) — 自动审批门控：Flash 预判写入/命令是否不可回补，安全操作自动批准、危险操作转人工（fail-safe）。
+- [dsh-verify](https://github.com/263311487-ux/dsh-verify) — 独立浏览器验收测试：JSON 清单驱动真实 Chromium，断言计算样式与像素差异，输出 HTML 报告 + 0/1 退出码；提供 npm CLI、GitHub Action 与 MCP Server。
 ### 🧩 技能包
 
 - [gongyijie85/dsh-ponytail](https://github.com/gongyijie85/dsh-ponytail) — 最懒资深工程师模式（Ponytail）的 DSH 移植：6 个技能（ponytail、ponytail-audit、ponytail-debt、ponytail-gain、ponytail-help、ponytail-review），改编自 DietrichGebert/ponytail（MIT）。


### PR DESCRIPTION
## dsh-verify — independent browser acceptance testing for agent deliverables

**One-line pitch:** Agents self-test and pass; real browsers tell the truth.

dsh-verify is a tiny, dependency-light acceptance tester for agent-delivered web artifacts. You write (or AI-draft) a JSON checklist of what a human would check in a browser; it launches real headless Chromium, clicks, reads computed styles, pixel-diffs screenshots, and produces an HTML report plus a `0/1` exit code.

**Why it exists:** a 4-agent web team shipped a demo with a dark-mode toggle; their own review said "no issues found" while the toggle literally did nothing in a real browser — the `.dark` CSS rule was missing. Every agent self-test passed because there was nothing to run. The repo ships the buggy and fixed builds side by side as proof.

**Features:**
- JSON spec → real Chromium → HTML report + exit code (drop into any CI)
- Visual regression: `capture_baseline` / `expect_screenshot` (pixel diff with red-highlight diff image)
- AI-drafted checklists: `dsh-verify gen --url <url> --run` (LLM drafts, deterministic browser enforces)
- MCP server (`verify_spec` / `verify_url` / `generate_and_verify`) for Claude Code / Cursor / Copilot
- GitHub Action (`uses: 263311487-ux/dsh-verify/.github/actions/dsh-verify`) — dogfooded on its own CI
- Published on npm (`dsh-verify`), installable via `dsh plugin add dsh-verify` (declares `dsh.bundle`)

16 self-tests green; detection proven end to end (buggy build caught via CLI, MCP, and Action).
