### PR TITLE
Add stopchewing/dsh-mcp-view - MCP servers & tools panel for the Web GUI

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -126,6 +126,8 @@ DeepSeek Harness is DeepSeek's open-source agent harness — a runnable coding a
 
 - [yoli-mi/dsh-client-ui-custom](https://github.com/yoli-mi/dsh-client-ui-custom) - Web theming (wallpaper, glass, accent, presets), keyboard shortcuts, usage stats, a plugin marketplace, a floating history strip, and user-message Markdown rendering.
 
+- [stopchewing/dsh-mcp-view](https://github.com/stopchewing/dsh-mcp-view) - MCP servers & tools inventory panel: one-click floating panel from the sidebar that lists every MCP server and tool (transport, endpoint, JSON schema, last-used time), grouped by server, collapsed by default, with live search and refresh; last-used times come from real session logs.
+
 ### Themes & Appearance
 
 - [Liu-ZA-81/dsh-theme-firefly](https://github.com/Liu-ZA-81/dsh-theme-firefly) — A Honkai: Star Rail "Firefly" theme: wallpaper/video backgrounds, firefly-green neon palette, transformation boot animation, ambient particles, BGM, typewriter SFX, and context-aware emote easter eggs.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 
 - [yoli-mi/dsh-client-ui-custom](https://github.com/yoli-mi/dsh-client-ui-custom) — Web 外观主题定制（壁纸、毛玻璃、强调色、预设）、键盘快捷键、用量统计、插件市场、浮动历史条与用户消息 Markdown 渲染。
 
+- [stopchewing/dsh-mcp-view](https://github.com/stopchewing/dsh-mcp-view) — MCP 服务器与工具清单面板：侧边栏一键悬浮面板，按服务器分组展示全部 MCP 工具（传输方式、端点、JSON Schema、最近使用时间），默认折叠、支持搜索与实时刷新；最近使用时间来自真实会话日志。
+
 ### 🎭 主题与外观
 
 - [Liu-ZA-81/dsh-theme-firefly](https://github.com/Liu-ZA-81/dsh-theme-firefly) — 崩坏：星穹铁道「流萤」主题：立绘/动态壁纸、萤火绿霓虹配色、开屏变身动画、萤火氛围粒子、背景音乐、打字音效与按对话触发的表情包彩蛋。


### PR DESCRIPTION
## What\r\n\r\nAdds [dsh-mcp-view](https://github.com/stopchewing/dsh-mcp-view) to **UI Enhancements** (README.md + README.en.md): a one-click floating panel listing every MCP server and tool in the DSH Web GUI - grouped by server, collapsed by default, with transport/endpoint, JSON input schemas, live search, auto-refresh, and last-used times derived from real session logs.\r\n\r\n## Checklist\r\n\r\n- [x] Added one line to README.md under the matching category\r\n- [x] Added one line to README.en.md under the matching category\r\n- [x] Format: - [owner/repo](url) - one-line description\r\n- [x] Repo has the dsh-plugin topic