### PR TITLE
添加 dsh-llm-local-token 插件

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -32,7 +32,7 @@ DeepSeek Harness is DeepSeek's open-source agent harness — a runnable coding a
 
 </details>
 
-**333** plugins · [PRs welcome](#contributing)
+**334** plugins · [PRs welcome](#contributing)
 
 ## Contents
 
@@ -348,6 +348,7 @@ DeepSeek Harness is DeepSeek's open-source agent harness — a runnable coding a
 - [btspoony/dsh-llm-fallbacks](https://github.com/btspoony/dsh-llm-fallbacks) - Role-based LLM retry & fallback strategies.
 - [franksong2702/dsh-codex-connect](https://github.com/franksong2702/dsh-codex-connect) - Connect ChatGPT OAuth and OpenAI Codex models to DeepSeek Harness, with opt-in search and image tools.
 - [kam74515-boop/dsh-everything-oauth](https://github.com/kam74515-boop/dsh-everything-oauth) - Import local Codex, Grok, Claude, OpenCode, and CC Switch logins into DSH; pick sources and enable models in Settings.
+- [tianxia--/dsh-llm-local-token](https://github.com/tianxia--/dsh-llm-local-token) - Reuses local Codex CLI and Claude Code OAuth credentials as OpenAI Codex and Anthropic model routes, with subscription usage shown in Web.
 - [omdsh-dev/Qwen-MM-Plugins](https://github.com/omdsh-dev/Qwen-MM-Plugins) - Qwen multi-modal plugin support.
 - [suntianc/dsh-codex-auth](https://github.com/suntianc/dsh-codex-auth) - Reuses the Codex CLI ChatGPT login as an `openai-codex` LLM route and adds GPT Auth controls to DSH Web settings.
 - [dsh-vision](https://github.com/dsh-external/dsh-vision) - Vision bridge: view_image tool over any OpenAI-compatible VLM.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 
 </details>
 
-**333** 个插件 · 欢迎 [PR](#贡献)
+**334** 个插件 · 欢迎 [PR](#贡献)
 
 ## 目录
 
@@ -349,6 +349,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [btspoony/dsh-llm-fallbacks](https://github.com/btspoony/dsh-llm-fallbacks) — 基于角色的模型重试与备用策略。
 - [franksong2702/dsh-codex-connect](https://github.com/franksong2702/dsh-codex-connect) — 通过 ChatGPT OAuth 将 OpenAI Codex 模型接入 DeepSeek Harness，并提供可选的搜索与图片工具。
 - [kam74515-boop/dsh-everything-oauth](https://github.com/kam74515-boop/dsh-everything-oauth) — 把本机 Codex / Grok / Claude / OpenCode / CC Switch 登录态导入 DSH，在设置里自选来源并启用模型。
+- [tianxia--/dsh-llm-local-token](https://github.com/tianxia--/dsh-llm-local-token) — 复用本机 Codex CLI 与 Claude Code 的 OAuth 凭据注册 OpenAI Codex 和 Anthropic 模型路由，并在 Web 中显示订阅用量。
 - [omdsh-dev/Qwen-MM-Plugins](https://github.com/omdsh-dev/Qwen-MM-Plugins) — Qwen 多模态插件支持。
 - [suntianc/dsh-codex-auth](https://github.com/suntianc/dsh-codex-auth) — 复用 Codex CLI 的 ChatGPT 登录态注册 `openai-codex` LLM 路由，并在 DSH Web 设置中提供 GPT Auth 控件。
 - [dsh-vision](https://github.com/dsh-external/dsh-vision) — 视觉桥接：view_image 工具接任意 OpenAI 兼容 VLM。


### PR DESCRIPTION
添加 `tianxia--/dsh-llm-local-token` 到「模型与账号接入 / Models & Providers」分类。该插件复用本机 Codex CLI 与 Claude Code 已持有的 OAuth 凭据，为 DSH 注册 OpenAI Codex 与 Anthropic 模型路由，并在 Web 中显示订阅用量。

- 插件仓库：https://github.com/tianxia--/dsh-llm-local-token
- v1.2.0 Release：https://github.com/tianxia--/dsh-llm-local-token/releases/tag/v1.2.0
- 已按贡献指南在 `README.md` 与 `README.en.md` 的对应分类各添加一行，并使用一行功能描述。
- 说明：npm 包 `dsh-llm-local-token` 正在发布落地中；目前 git URL 安装路径可用。

<!-- Checklist from the PR template / 按 PR 模板自查 -->
- [ ] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`) / 仓库 `package.json` 已声明 `dsh.bundle`（当前上游 package.json 只公开了 `dsh.client`；需作者在合并前确认/补齐）
- [x] One line added to **both** `README.en.md` (English) and `README.md` (中文), under the matching category / 两个语言文件各加一行，放对分类
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic / 仓库已打 `dsh-plugin` topic

**Recommended / 推荐**
- [ ] Publish to npm / 发布 npm 包（正在发布中，当前 `npm view dsh-llm-local-token` 仍返回 404）
- [x] Declare official `@deepseek-ai/*` packages as peerDependencies / 官方包已使用 peerDependencies。
