### PR TITLE
Add huxint/dsh-team

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -323,6 +323,7 @@ DeepSeek Harness is DeepSeek's open-source agent harness — a runnable coding a
 - [Letter2025/dsh-model-failover](https://github.com/Letter2025/dsh-model-failover) - Two-level model circuit breaker with failover: trip a model or a whole provider after repeated request failures and route the next request to a configured fallback.
 - [dsh-plan-execute](https://github.com/dsh-external/dsh-plan-execute) - Dual-model plan/execute routing: a planner model thinks, an executor model acts.
 - [timwhitez/dsh-self-evolving](https://github.com/timwhitez/dsh-self-evolving) - Evidence-first, crash-resumable self-evolution engine for DSH: bounded Cordis candidate generation, one-shot real-Loader admission, Harbor evaluation, and an auditable journaled lineage.
+- [huxint/dsh-team](https://github.com/huxint/dsh-team) - Agent teams: spawn named long-lived teammates, coordinate them with a shared task list, member mailbox, and virtual workspaces, and watch the team live in a team-room tab.
 
 ### Notifications & Integrations
 

--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [Letter2025/dsh-model-failover](https://github.com/Letter2025/dsh-model-failover) — 两级模型熔断与回退：模型或平台连续失败后自动熔断，并把下一个请求路由到配置好的备用模型。
 - [dsh-plan-execute](https://github.com/dsh-external/dsh-plan-execute) — plan/execute 双模型路由：规划模型思考、执行模型干活。
 - [timwhitez/dsh-self-evolving](https://github.com/timwhitez/dsh-self-evolving) — 证据优先、可崩溃恢复的自进化引擎：有界生成 Cordis 候选插件、一次性真实 Loader 准入、Harbor 评估，并保留可审计的日志化谱系。
+- [huxint/dsh-team](https://github.com/huxint/dsh-team) — Agent 团队：派生具名常驻队友，用共享任务列表、成员邮箱与虚拟工作区协作，并在协作室页签里实时观察团队。
 
 ### 🔔 通知与集成
 


### PR DESCRIPTION
## Checklist

- [x] 仓库 `package.json` 已声明 **`dsh.bundle`**（`bundle.patch` → `cordis.patch.yml`，另带 `dsh.client` 提供协作室 UI）
- [x] 两个语言文件 `README.en.md`（English）与 `README.md`（中文）各加一行，放于 Workflow & Automation / 工作流与自动化
- [x] 描述只说功能，不带营销词
- [x] 仓库已打 `dsh-plugin` topic

## 关于插件

[huxint/dsh-team](https://github.com/huxint/dsh-team) 给 dsh 加一支 Agent 团队：主会话作为 leader，通过 `ctx.subagents` 派生具名常驻队友（各自带会话、记忆与工具）；成员之间经邮箱互发消息（投递始终由 leader 权威执行，带链式跳数预算），共享一份任务列表，另有两个虚拟工作区（共享黑板 + 每人一块私有便笺）。会话视图环新增「Agent 团队」页签，实时渲染花名册、协作关系与消息流。

一个包、一行装配：宿主半边（`dsh-team`）与浏览器半边（`dsh-team/client`）从同一个 `package.json` 构建。

备注：已发布 npm（`dsh-team@0.2.1`），可用 `dsh plugin add` 一行安装（预构建产物免 `allowBuilds` 授权）。
