### PR TITLE
Add dream-num/dsh-univer-office to Tools & Capabilities

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -219,6 +219,7 @@ DeepSeek Harness is DeepSeek's open-source agent harness — a runnable coding a
 - [dsh-browser-panel](https://github.com/dsh-external/dsh-browser-panel) - Headed browser embedded in the WebUI, model-driven and zero vision deps.
 - [dsh-office](https://github.com/dsh-external/dsh-office) - Model reads/edits Office files with docx/pdf preview in the web client.
 - [dsh-market/dsh-market](https://github.com/dsh-market/dsh-market) - The plugin market inside DSH: a Settings page to browse and search the full community catalog by category, with confirmed one-click installs and an installed-plugins view.
+- [dream-num/dsh-univer-office](https://github.com/dream-num/dsh-univer-office) - Create, edit, inspect, and deliver spreadsheets, documents, presentations, databases, and canvases in DeepSeek Harness, with live preview and worktree review.
 - [EvilIrving/dsh-context-proxy](https://github.com/EvilIrving/dsh-context-proxy) - Thin on-demand context retrieval: context_query / context_slice / context_grep tools that read already-persisted history back with replay-safe citations.
 - [flymysql/dsh-remote](https://github.com/flymysql/dsh-remote) - Remote workspace: connect a host over SSH (password or key), pick a remote workspace directory and operate on it with rw_pick_workspace / rw_list_dir / rw_read_file / rw_exec tools.
 - [futongxu9-maker/dsh-path-reveal](https://github.com/futongxu9-maker/dsh-path-reveal) - Click any absolute Windows path in DSH messages to reveal it in Explorer (select the file or open the folder).

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [dsh-browser-panel](https://github.com/dsh-external/dsh-browser-panel) — WebUI 内嵌有头浏览器，模型实时操控、0 视觉依赖。
 - [dsh-office](https://github.com/dsh-external/dsh-office) — 模型读写 Office 文件，web 客户端 docx/pdf 预览。
 - [dsh-market/dsh-market](https://github.com/dsh-market/dsh-market) — 装在 DSH 里的插件市场：设置页内逛/搜全部社区插件，按分类筛选，确认后一键安装，已装插件一目了然。
+- [dream-num/dsh-univer-office](https://github.com/dream-num/dsh-univer-office) — 在 DeepSeek Harness 中创建、编辑、检查和交付表格、文档、演示文稿、多维表格和画布，支持实时预览与 worktree 审阅。
 - [EvilIrving/dsh-context-proxy](https://github.com/EvilIrving/dsh-context-proxy) — 按需取回薄层：context_query / context_slice / context_grep 三个工具读取已持久化的历史，引用可回放。
 - [flymysql/dsh-remote](https://github.com/flymysql/dsh-remote) — 远程工作区：SSH 密码或 key 连接远程主机，选取远程工作区目录，用 rw_pick_workspace / rw_list_dir / rw_read_file / rw_exec 工具在远程直接操作。
 - [futongxu9-maker/dsh-path-reveal](https://github.com/futongxu9-maker/dsh-path-reveal) — 点击消息里的 Windows 绝对路径在资源管理器中打开所在文件夹（文件定位选中/目录直接打开）。


### PR DESCRIPTION
# Add dream-num/dsh-univer-office to Tools & Capabilities

## Summary

Adds [dream-num/dsh-univer-office](https://github.com/dream-num/dsh-univer-office) to the **Tools & Capabilities** section in both `README.en.md` and `README.md`.

## What it does

- Creates and edits Sheets, Docs, Slides, Bases, and Boards in `.univer` files.
- Imports `.xlsx`, `.csv`, `.tsv`, `.docx`, and `.pptx` files, and exports edited content back to the matching Office format.
- Verifies changes through structured readback, formula recalculation, and Slide layout checks.
- Uses isolated worktrees for every write; users can preview, merge, or discard changes from the conversation.
- Ships version-matched Skills and `univer_*` tools, plus a bundled Gateway, Viewer, and Unit Content Worker.

## Checklist

- [x] `package.json` declares `dsh.bundle` with `cordis.patch.yml`
- [x] `dsh-plugin` GitHub topic enabled
- [x] Published on npm (`dsh-univer-office`, Apache-2.0)
- [x] Added one line to `README.en.md`
- [x] Added one line to `README.md`
- [x] Installable via `dsh plugin --profile web add dsh-univer-office`
