### PR TITLE
Add SandBase Skills bundle

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -327,6 +327,7 @@ DeepSeek Harness is DeepSeek's open-source agent harness — a runnable coding a
 - [skill-manager](https://github.com/JohnXu22786/skill-manager) - Multi-zone skill discovery, progressive disclosure, creation wizard, audit and statistics.
 - [spec-driven](https://github.com/JohnXu22786/spec-driven) - keel (龙骨): spec-driven development discipline skill pack — spec first, verify assumptions, prevent over-engineering.
 - [leechen298/Code2Skill](https://github.com/leechen298/Code2Skill) - Generates Function, MCP, Agent Skill, and offline test packages from existing code as an installable DSH bundle.
+- [sandbaseai/sandbase-skills](https://github.com/sandbaseai/sandbase-skills) - 88 Agent Skills for research, social intelligence, marketing, and business workflows, mounted through a native DSH bundle with optional project-scoped installation of multi-source-search.
 - [yanglaofish/dsh-skill-manager](https://github.com/yanglaofish/dsh-skill-manager) - Skill lifecycle manager for DSH: list / edit / import / enable / disable skills under a global-workspace-session three-layer model, with unified settings & conversation UI, cross-layer search and pagination.
 
 ### Workflow & Automation

--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [skill-manager](https://github.com/JohnXu22786/skill-manager) — 多区域技能发现、渐进式披露、创建向导、审计与统计。
 - [spec-driven](https://github.com/JohnXu22786/spec-driven) — keel（龙骨）：规格驱动开发纪律技能包——先立规格、验证假设、防止过度工程与范围蔓延。
 - [leechen298/Code2Skill](https://github.com/leechen298/Code2Skill) — 从现有代码生成 Function、MCP、Agent Skill 和离线测试包，并作为可安装的 DSH Bundle 分发。
+- [sandbaseai/sandbase-skills](https://github.com/sandbaseai/sandbase-skills) — 88 个面向研究、社交情报、营销与商业工作流的 Agent Skills，通过原生 DSH bundle 挂载技能目录，也可按项目单独安装 multi-source-search。
 - [yanglaofish/dsh-skill-manager](https://github.com/yanglaofish/dsh-skill-manager) — DSH 技能生命周期管理插件：全局 / 工作区 / 会话三层模型下查看、编辑、导入、启用/停用技能，设置页与对话页统一管理界面，支持跨层全文搜索与分页。
 
 ### 🔁 工作流与自动化


### PR DESCRIPTION
Adds `sandbaseai/sandbase-skills` to the Skills category in both Chinese and English.

The repository meets the listing requirements:

- root `package.json` declares a native `dsh.bundle` manifest
- contains 88 working `SKILL.md` packages and an installable bundle patch
- actively maintained and tagged `dsh-plugin`
- descriptions are factual and end with punctuation
- entries are sorted alphabetically

Validation: `node scripts/check-order.mjs` → `order OK` and `git diff --check` passed.

Affiliation disclosure: I am affiliated with the SandBase project.