### PR TITLE
Add dsh-flat-teams (Workflow & Automation)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -364,6 +364,7 @@ DeepSeek Harness is DeepSeek's open-source agent harness — a runnable coding a
 - [titanwings/dsh-automation](https://github.com/titanwings/dsh-automation) - Scheduled coding runs in fresh agent sessions with auditable history.
 - [titanwings/dsh-plannotator](https://github.com/titanwings/dsh-plannotator) - Plan review with anchored annotations and structured feedback back to the agent.
 - [vlln/dsh-loop](https://github.com/vlln/dsh-loop) - Recurring loops: `/loop` command + loop tool + activity status bar.
+- [whateverboy2333/dsh-flat-teams](https://github.com/whateverboy2333/dsh-flat-teams) - Leaderless flat agent teams: cross-window structured task dispatch (state machine + event stream + offline resume), a read-only progress recorder, and a two-level web dashboard.
 
 ### Notifications & Integrations
 - [Andyqwe44/dsh-notify-win](https://github.com/Andyqwe44/dsh-notify-win) - Native Windows toast + taskbar flash for task done / approval / ask_user_question, Win10/11, npm install `dsh plugin --profile web add dsh-notify-win`.

--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [titanwings/dsh-automation](https://github.com/titanwings/dsh-automation) — 定时任务：让 Coding 任务按计划在全新 Agent Session 中运行，保留可审计历史。
 - [titanwings/dsh-plannotator](https://github.com/titanwings/dsh-plannotator) — 计划批注：选中计划原文逐条批注，结构化反馈送回 Agent。
 - [vlln/dsh-loop](https://github.com/vlln/dsh-loop) — 定时循环：`/loop` 命令 + loop 工具 + 活动状态条。
+- [whateverboy2333/dsh-flat-teams](https://github.com/whateverboy2333/dsh-flat-teams) — 无队长扁平 Agent 团队：跨窗口结构化任务派发（状态机 + 事件流 + 离线唤醒）、记录员进展服务与 Web 两级看板。
 
 ### 🔔 通知与集成
 - [Andyqwe44/dsh-notify-win](https://github.com/Andyqwe44/dsh-notify-win) — 原生 Windows toast + 任务栏闪烁，任务完成/审批/提问时触发，支持 Win10/11，npm 安装 `dsh plugin --profile web add dsh-notify-win`。


### PR DESCRIPTION
收录 dsh-flat-teams：无队长扁平 Agent 团队插件。

- 仓库：https://github.com/whateverboy2333/dsh-flat-teams （已打 dsh-plugin topic）
- package.json 声明完整 dsh.bundle manifest（cordis.patch.yml 在仓库根），同时带 dsh.client（Web 看板）
- 真实可用代码：host 面 12 个模型工具 + 管理端点 + 记录员服务，client 面看板 bundle；预构建 lib/ 已入库，git 安装免构建授权
- 功能：跨窗口结构化任务派发（状态机/事件流/离线唤醒）、只读记录员进展服务、两级 Web 看板、用户专属解散/踢出管理
- 已按字母序插入 README.md 与 README.en.md 的 Workflow & Automation 分类，check-order.mjs 本地通过