### PR TITLE
Add DSH Agent Market (AI-native plugin marketplace) to Related

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -494,6 +494,7 @@ DeepSeek Harness is DeepSeek's open-source agent harness — a runnable coding a
 - [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) - Official runtime and core documentation.
 - [DeepSeek](https://deepseek.com) - Official site.
 - [dsh-ops](https://github.com/MiraculousGarfield/dsh-ops) - Standalone ops toolkit for dsh: one-click health check, config snapshot/restore, service watchdog and an incident runbook (plain PowerShell, no AI needed).
+- [DSH Agent Market](https://github.com/chenzhi-clude/dsh-plugin-market) - AI-native DSH plugin marketplace: 3600+ plugins auto-collected and categorized daily, with a machine-readable registry (all.json) and llms.txt so AI agents can search, trust, and install plugins.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) - 官方运行时与核心文档。
 - [DeepSeek](https://deepseek.com) - 官方入口。
 - [dsh-ops](https://github.com/MiraculousGarfield/dsh-ops) - dsh 运维工具箱：一键健康检查、配置快照/还原、服务看门狗与事故运维手册（纯本地脚本，无需 AI）。
+- [DSH Agent Market](https://github.com/chenzhi-clude/dsh-plugin-market) - AI 原生 DSH 插件市场：3600+ 插件每日自动采集与分类，提供机器可读注册表（registry/all.json）与 llms.txt，AI 助手可直接搜索、认可并一键安装插件。
 
 ## 贡献
 


### PR DESCRIPTION
## What

Adds **DSH Agent Market** (https://github.com/chenzhi-clude/dsh-plugin-market) to the 相关 / Related section — both README.md and README.en.md.

## Why it fits

DSH Agent Market is an AI-native plugin marketplace for DeepSeek Harness:

- 3600+ community plugins auto-collected daily from GitHub by CI, categorized into 11 categories
- Machine-readable registry (`registry/all.json`) + [llms.txt](https://chenzhi-clude.github.io/dsh-plugin-market/llms.txt) so **AI coding agents can search, evaluate, and one-click-install plugins** on behalf of users
- Browsable web catalog: https://chenzhi-clude.github.io/dsh-plugin-market/
- Plugin submission via PR to `registry/curated/` (goes live in seconds), same contribution model as this list

It complements this awesome list (human-curated directory) by serving the AI-agent discovery path. Thanks for reviewing!