### PR TITLE
添加 dsh-plugin-cloud（DSH Cloud 网关接入）

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [SeverusZh/dsh-notify-windows](https://github.com/SeverusZh/dsh-notify-windows) — Windows 通知，零依赖。
 
 ### 🔌 模型与账号接入
+- [AgentsDanceAI/dsh-plugin-cloud](https://github.com/AgentsDanceAI/deepseek-harness-cloud/tree/main/packages/dsh-plugin-cloud) — 接入 DSH Cloud 网关（托管或自部署）：设备授权登录，一条命令在用户配置层写入多模型 provider（DeepSeek / GPT / Claude / Gemini 等 20 个模型）。
 - [btspoony/dsh-llm-fallbacks](https://github.com/btspoony/dsh-llm-fallbacks) — 基于角色的模型重试与备用策略。
 - [dsh-vision](https://github.com/dsh-external/dsh-vision) — 视觉桥接：view_image 工具接任意 OpenAI 兼容 VLM。
 - [dylan121322/llm-adaptive](https://github.com/dylan121322/llm-adaptive) — 自适应模型路由：请求级复杂度分类，按配置链自动选择后端 provider。


### PR DESCRIPTION
按分类加入「🔌 模型与账号接入」，段内按 owner 字母序插入。插件已发 npm（`dsh-plugin-cloud`），仓库挂 `dsh-plugin` topic，monorepo 子包路径 `packages/dsh-plugin-cloud`。利益相关：本人维护。