### PR TITLE
收录 dsh-pianist（AI 钢琴演奏插件）

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -504,6 +504,7 @@ DeepSeek Harness is DeepSeek's open-source agent harness — a runnable coding a
 - [hellodigua/dsh-emoji](https://github.com/hellodigua/dsh-emoji) - Automatically add emojis to AI replies.
 - [HuanLinOTO/dsh-plugin-d399](https://github.com/HuanLinOTO/dsh-plugin-d399) - Pops up a mini-game menu (wordle, match-3, extensible) while the model generates.
 - [JAdpp/dsh-whale-galgame](https://github.com/JAdpp/dsh-whale-galgame) - Multi-character Galgame conversation view with separate character and reply-model selection, per-character affection, memory, dialogue history, and CG galleries, plus responses informed by task events across Harness sessions.
+- [Laplace-bit/dsh-pianist](https://github.com/Laplace-bit/dsh-pianist) - AI piano performance: ask the agent to play a piece on a Canvas2D grand piano with real Salamander Grand samples and a playable 88-key keyboard.
 - [lhh010/dsh-minigames](https://github.com/lhh010/dsh-minigames) - Side-panel arcade: 18 offline mini-games to play while the model thinks.
 - [minybear/DeepSeek-Harness-Pet](https://github.com/minybear/DeepSeek-Harness-Pet) - Codex-style desktop pet: a floating animated sprite in the corner that mirrors the agent's running state (working, waiting, failed, done).
 - [Moeblack/deepseek-manners](https://github.com/Moeblack/deepseek-manners) - Append a thank-you note after every message. Mind your manners.

--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [hellodigua/dsh-emoji](https://github.com/hellodigua/dsh-emoji) — 为 AI 回复自动添加表情。
 - [HuanLinOTO/dsh-plugin-d399](https://github.com/HuanLinOTO/dsh-plugin-d399) — 模型生成时弹出小游戏菜单（wordle/消消乐，可扩展）。
 - [JAdpp/dsh-whale-galgame](https://github.com/JAdpp/dsh-whale-galgame) — 多角色 Galgame 对话界面：角色与回复模型可独立切换，分角色保存好感度、记忆、对话历史与 CG 图鉴，并根据 Harness 跨会话任务事件做出角色回应。
+- [Laplace-bit/dsh-pianist](https://github.com/Laplace-bit/dsh-pianist) — AI 钢琴演奏：让 Agent 弹一曲真钢琴，Canvas2D 三角钢琴 + Salamander Grand 真实采样音色，88 键可弹，附沉浸式舞台。
 - [lhh010/dsh-minigames](https://github.com/lhh010/dsh-minigames) — 右侧小游戏面板：18 款离线小游戏，等模型回复时的摸鱼神器。
 - [minybear/DeepSeek-Harness-Pet](https://github.com/minybear/DeepSeek-Harness-Pet) — Codex 风格桌面宠物：右下角悬浮动画精灵，随 agent 运行状态实时变化（工作、等待、报错、完成）。
 - [Moeblack/deepseek-manners](https://github.com/Moeblack/deepseek-manners) — 给每次消息后注入感谢语，做个有礼貌的人。


### PR DESCRIPTION
按贡献格式在 `README.md` 与 `README.en.md` 的 🎮 娱乐 分类各加一行。

[dsh-pianist](https://github.com/Laplace-bit/dsh-pianist)：让 Agent 弹一曲真钢琴——Canvas2D 三角钢琴实时渲染、Salamander Grand V3 真实采样音色、88 键可弹键盘与全屏沉浸式舞台。声明 `dsh.bundle` manifest 可用 `dsh plugin add` 安装，npm 包名 `dsh-pianist@0.1.0`。仓库已带 `dsh-plugin` topic。