### PR TITLE
docs: link handbook in related resources

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -531,6 +531,7 @@ DeepSeek Harness is DeepSeek's open-source agent harness — a runnable coding a
 ## Related
 
 - [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) - Official runtime and core documentation.
+- [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook) - Agent-first multilingual operator handbook with source-backed guides for MCP, Skills, Subagents, sandboxing, and troubleshooting.
 - [DeepSeek](https://deepseek.com) - Official site.
 - [dsh-ops](https://github.com/MiraculousGarfield/dsh-ops) - Standalone ops toolkit for dsh: one-click health check, config snapshot/restore, service watchdog and an incident runbook (plain PowerShell, no AI needed).
 - [DSH Agent Market](https://github.com/chenzhi-clude/dsh-plugin-market) - AI-native DSH plugin marketplace: 3600+ plugins auto-collected and categorized daily, with a machine-readable registry (all.json) and llms.txt so AI agents can search, trust, and install plugins.

--- a/README.md
+++ b/README.md
@@ -531,6 +531,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 ## 相关
 
 - [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) - 官方运行时与核心文档。
+- [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook) - Agent-first 多语言操作手册：源码关联指南、MCP/Skills/Subagents、沙箱与故障排查。
 - [DeepSeek](https://deepseek.com) - 官方入口。
 - [dsh-ops](https://github.com/MiraculousGarfield/dsh-ops) - dsh 运维工具箱：一键健康检查、配置快照/还原、服务看门狗与事故运维手册（纯本地脚本，无需 AI）。
 - [DSH Agent Market](https://github.com/chenzhi-clude/dsh-plugin-market) - AI 原生 DSH 插件市场：3600+ 插件每日自动采集与分类，提供机器可读注册表（registry/all.json）与 llms.txt，AI 助手可直接搜索、认可并一键安装插件。


### PR DESCRIPTION
Add the DeepSeek Harness Handbook to the Related resources section in both Chinese and English READMEs.

The handbook is an independent, source-backed multilingual operator guide and is clearly labeled as documentation rather than a plugin.