### PR TITLE
Add lcthe/dsh-hermes-memory to memory plugins

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -187,6 +187,7 @@ DeepSeek Harness is DeepSeek's open-source agent harness — a runnable coding a
 - [yuezengwu/dsh-explain](https://github.com/yuezengwu/dsh-explain) - Local-first learning mode: cross-session learning threads with per-source explanations.
 
 ### Memory
+- [lcthe/dsh-hermes-memory](https://github.com/lcthe/dsh-hermes-memory) - DSH-native persistent memory: session-aware retrieval, standing context, crash-safe consolidation, and storage-backed skills.
 - [Bionic-forest/dsh-memory_rollout](https://github.com/Bionic-forest/dsh-memory_rollout) - Codex-style per-session memory for DSH: one session one draft (rollout_summaries), layered disclosure (summary → registry → drafts/evidence), restrained & passive, idempotent integration, remembers facts/preferences/decisions across sessions with verifiable citations, npm package `dsh-memory_rollout`.
 - [dsh-context](https://github.com/bowenliang123/dsh-context) - Context insight panel: see what the model's context window is made of and how it evolves — composition vs. window size, per-request history, compression/injection events, and per-message token stats.
 - [Breeze136/dsh-kb-rag](https://github.com/Breeze136/dsh-kb-rag) - Local literature knowledge-base RAG: 8 tools (PDF/folder/Zotero ingest, hybrid BM25+vector+reranker search, cited QA with clickable DOI links, scope/strict modes, dedup/clear/stats), all-local bge embeddings + single-file SQLite, measured 242-doc/86s ingest and sub-second hot queries on 20k chunks.

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [yuezengwu/dsh-explain](https://github.com/yuezengwu/dsh-explain) — 本地优先学习模式：跨会话全局学习线程、按来源讲解。
 
 ### 🧠 记忆
+- [lcthe/dsh-hermes-memory](https://github.com/lcthe/dsh-hermes-memory) — 面向 DSH 的原生持久记忆插件：会话检索、常驻上下文、崩溃安全合并和本地技能存储。
 - [Bionic-forest/dsh-memory_rollout](https://github.com/Bionic-forest/dsh-memory_rollout) — Codex 风格的 DSH 会话持久记忆：一会话一草稿（rollout_summaries）、分层披露（summary→注册表→草稿/证据）、克制被动、幂等整合，跨会话记住事实/偏好/决策并带可核验引用，npm 包名 `dsh-memory_rollout`。
 - [bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context) — 上下文洞察面板：一眼看清模型上下文窗口的组成与变化——构成对照窗口大小、按请求历史趋势、压缩/注入事件、消息级 token 统计。
 - [Breeze136/dsh-kb-rag](https://github.com/Breeze136/dsh-kb-rag) — 本地文献知识库 RAG：8 个工具（PDF/文件夹/Zotero 入库、BM25+向量+重排混合检索、DOI 可点击溯源问答、范围/严格模式、去重/清空/统计），全本地 bge 嵌入 + 单文件 SQLite，实测 242 篇 86s 入库、2 万块亚秒热查询。


### PR DESCRIPTION
## Plugin

[lcthe/dsh-hermes-memory](https://github.com/lcthe/dsh-hermes-memory)

## Relation to DSH

A native DeepSeek Harness plugin that provides persistent memory, session-aware retrieval, user-approved standing context, crash-safe memory consolidation, and storage-backed skills through DSH plugin seams.

## Install

- npm: `@lcthe/dsh-hermes-memory@0.2.2`
- DSH profile bundle: `dsh plugin --profile web add @lcthe/dsh-hermes-memory`

The published package includes the DSH bundle patch metadata.

## Checklist

- MIT license added
- `dsh-plugin` GitHub topic enabled
- English entry added to `README.en.md`
- Chinese entry added to `README.md`
- Current GitHub stars: 0
- No duplicate entry found
