### PR TITLE
Add weibaohui/dsh-xiuxian（修仙陪伴）

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -534,6 +534,8 @@ DeepSeek Harness is DeepSeek's open-source agent harness — a runnable coding a
 - [vlln/whale-girl](https://github.com/vlln/whale-girl) - Desktop pet (QQ-pet style): floats in the corner, draggable, feedable, playable.
 - [william-jin-cmu/dsh-stickers](https://github.com/william-jin-cmu/dsh-stickers) - Bidirectional sticker reactions between user and agent.
 
+- [weibaohui/dsh-xiuxian](https://github.com/weibaohui/dsh-xiuxian) - Xianxia desktop pets tied to live agent sessions: pixel-style companions appear as subagents spawn (up to 3 on screen), with storage-bag collection, a right-click artifact menu, a pet gallery, and Codex pet-format export.
+
 ## Related
 
 - [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) - Official runtime and core documentation.

--- a/README.md
+++ b/README.md
@@ -534,6 +534,8 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [vlln/whale-girl](https://github.com/vlln/whale-girl) — 桌面宠物（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍。
 - [william-jin-cmu/dsh-stickers](https://github.com/william-jin-cmu/dsh-stickers) — 用户与 agent 双向表情贴纸互动。
 
+- [weibaohui/dsh-xiuxian](https://github.com/weibaohui/dsh-xiuxian) — 修仙陪伴：MC 像素风桌宠与 agent 会话实时联动，子代理启动时化身宠物现身（最多 3 只同屏），储物袋收藏、右键法宝菜单、图鉴选宠，可导出 Codex 桌宠格式。
+
 ## 相关
 
 - [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) - 官方运行时与核心文档。


### PR DESCRIPTION
收录 **weibaohui/dsh-xiuxian**（修仙陪伴）到 🎮 娱乐 / Just for Fun。

MC 像素风修仙桌宠与 agent 会话实时联动：子代理启动时化身宠物现身（最多 3 只同屏），储物袋收藏、右键法宝菜单、图鉴选宠，可导出 Codex 桌宠格式。

- 📦 npm: [@weibaohui/dsh-xiuxian](https://www.npmjs.com/package/@weibaohui/dsh-xiuxian)（v1.1.1）→ `dsh plugin --profile web add @weibaohui/dsh-xiuxian`
- ✅ `package.json` 声明 `dsh.bundle`（含 `cordis.patch.yml`）
- ✅ 仓库已打 `dsh-plugin` topic
- 🖼️ 演示：https://github.com/weibaohui/dsh-xiuxian/blob/main/docs/demo.gif

- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`)
- [x] One line added to **both** `README.en.md` and `README.md`, under the matching category / 两个语言文件各加一行
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic
- [x] 📦 Published to npm / 已发布 npm 包
