### PR TITLE
添加 dsh-split-screen（分屏工作区）

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [xiaogu619520/dsh-plugin-task-panel](https://github.com/xiaogu619520/dsh-plugin-task-panel) — 任务摘要与上下文用量监控浮动面板（待办事项跟踪、文件与系统 Token 占用统计、8向缩放与快捷键）。
 - [YEYEYEYESHIFU/dsh-result-only-view](https://github.com/YEYEYEYESHIFU/dsh-result-only-view) - 「只看结果」开关：折叠思考与工具调用过程行，对话只留用户消息与最终回复；运行中显示实时摘要芯片，回合后可点击痕迹行展开过程（支持悬停预览与自动/手动折叠）。
 - [YEYEYEYESHIFU/dsh-session-hotkeys](https://github.com/YEYEYEYESHIFU/dsh-session-hotkeys) — 会话热键管理：像切浏览器标签页一样用键盘切换会话——Alt+1-9 顺序切换、固定槽位、上/下一个、新建/归档/重命名、键盘模型切换与备用发送，键位可在面板录制重绑，Windows/macOS 双预设。
+- [YEYEYEYESHIFU/dsh-split-screen](https://github.com/YEYEYEYESHIFU/dsh-split-screen) — 分屏工作区：多个会话并排聊天，面板观感与原生对话完全一致，Alt+T 切换 TUI 输入模式，Alt+Shift+方向键切换面板焦点。
 - [yoli-mi/dsh-client-ui-custom](https://github.com/yoli-mi/dsh-client-ui-custom) — Web 外观主题定制（壁纸、毛玻璃、强调色、预设）、键盘快捷键、用量统计、插件市场、浮动历史条与用户消息 Markdown 渲染。
 - [yyyyukari/dsh-plugin-workshop](https://github.com/yyyyukari/dsh-plugin-workshop) — 创意工坊式插件浏览器：一键安装/更新/卸载。
 - [zealot00/dsh-pet](https://github.com/zealot00/dsh-pet) — DSH Web UI 桌面宠物：精灵图动画、agent 状态联动、拖拽、闹钟（每天/一次）与番茄钟，皮肤下拉选择 + 预览。


### PR DESCRIPTION
## 添加 dsh-split-screen

- 仓库：https://github.com/YEYEYEYESHIFU/dsh-split-screen
- npm：https://www.npmjs.com/package/dsh-split-screen（v1.0.0 已发布）
- 分类：🎨 UI 增强

分屏工作区：多个会话并排聊天，面板观感与原生 DeepSeek 对话完全一致（明暗主题适配）。

### 亮点

- 常开设计：单会话时无任何额外外观，与原生视图一致
- 从侧边栏拖拽会话到面板边缘即可分屏，拖到中间则替换该面板的会话，拖拽时有实时分屏预览
- 面板完全可交互：流式输出、Enter 发送、/commands、Stop、排队消息、todos
- 支持图片粘贴与拖拽附件
- 紧凑 TUI 输入模式（Alt+T），与完整模式宽度、按钮位置一致
- 内置快捷键：Alt+T（作曲器模式）、Alt+Shift+方向键（面板焦点切换）
