### PR TITLE
Add weibaohui/dsh-tasks（定时任务）

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -410,6 +410,7 @@ DeepSeek Harness is DeepSeek's open-source agent harness — a runnable coding a
 - [titanwings/dsh-automation](https://github.com/titanwings/dsh-automation) - Scheduled coding runs in fresh agent sessions with auditable history.
 - [titanwings/dsh-plannotator](https://github.com/titanwings/dsh-plannotator) - Plan review with anchored annotations and structured feedback back to the agent.
 - [vlln/dsh-loop](https://github.com/vlln/dsh-loop) - Recurring loops: `/loop` command + loop tool + activity status bar.
+- [weibaohui/dsh-tasks](https://github.com/weibaohui/dsh-tasks) - Scheduled tasks: run a prompt on cron schedules, each run opens a new agent session to do the work, with workspace binding, manual run, session auto-naming, and a fullscreen task management page.
 - [whateverboy2333/dsh-flat-teams](https://github.com/whateverboy2333/dsh-flat-teams) - Leaderless flat agent teams: cross-window structured task dispatch (state machine + event stream + offline resume), a read-only progress recorder, and a two-level web dashboard.
 
 ### Notifications & Integrations

--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [titanwings/dsh-automation](https://github.com/titanwings/dsh-automation) — 定时任务：让 Coding 任务按计划在全新 Agent Session 中运行，保留可审计历史。
 - [titanwings/dsh-plannotator](https://github.com/titanwings/dsh-plannotator) — 计划批注：选中计划原文逐条批注，结构化反馈送回 Agent。
 - [vlln/dsh-loop](https://github.com/vlln/dsh-loop) — 定时循环：`/loop` 命令 + loop 工具 + 活动状态条。
+- [weibaohui/dsh-tasks](https://github.com/weibaohui/dsh-tasks) — 定时任务：用 cron 表达式定时执行提示词，到点自动开一个新 agent 会话替你干活，支持绑定工作区、手动立即执行与会话自动命名。
 - [whateverboy2333/dsh-flat-teams](https://github.com/whateverboy2333/dsh-flat-teams) — 无队长扁平 Agent 团队：跨窗口结构化任务派发（状态机 + 事件流 + 离线唤醒）、记录员进展服务与 Web 两级看板。
 
 ### 🔔 通知与集成


### PR DESCRIPTION
收录 **weibaohui/dsh-tasks**（定时任务）到 🔁 工作流与自动化 / Workflow & Automation。

用 cron 表达式定时执行提示词，到点自动开一个新 agent 会话替你干活，支持绑定工作区、手动立即执行与会话自动命名。

- 📦 npm: [@weibaohui/dsh-tasks](https://www.npmjs.com/package/@weibaohui/dsh-tasks)（v0.4.2）→ `dsh plugin --profile web add @weibaohui/dsh-tasks`
- ✅ `package.json` 声明 `dsh.bundle`（含 `cordis.patch.yml`）
- ✅ 仓库已打 `dsh-plugin` topic
- 🖼️ 演示：https://github.com/weibaohui/dsh-tasks/blob/main/docs/demo.gif

- [x] My repo's `package.json` declares **`dsh.bundle`** (not just `dsh.client`)
- [x] One line added to **both** `README.en.md` and `README.md`, under the matching category / 两个语言文件各加一行
- [x] Description states what the plugin does, no superlatives / 描述只说功能，不带营销词
- [x] My repo has the `dsh-plugin` topic
- [x] 📦 Published to npm / 已发布 npm 包
