### PR TITLE
Add yindf/taskfold (Sessions & Messages)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -194,6 +194,7 @@ DeepSeek Harness is DeepSeek's open-source agent harness — a runnable coding a
 - [weibaohui/dsh-continue](https://github.com/weibaohui/dsh-continue) - Auto-resume for interrupted sessions: rules route by failure type (rate limit, quota, auth, context overflow, crashed orphan) into backoff retry, model switch, resume-after-compaction, or stop-loss notification, with a visual rule editor and activity log.
 - [weibaohui/dsh-smart-title](https://github.com/weibaohui/dsh-smart-title) - Smart session titles for DSH: after each conversation turn an independent auxiliary LLM call summarizes the full user+assistant transcript into a title that follows the session's real topic instead of echoing the first message; the first message is titled instantly, failed built-in titles auto-retry on later turns, manual renames are never overwritten, and subagent/fork sessions are skipped.
 - [Wine-Red/dsh-prompt-stash](https://github.com/Wine-Red/dsh-prompt-stash) - Local, per-session LIFO prompt stash for temporarily setting aside unfinished composer text and safely restoring it later.
+- [yindf/taskfold](https://github.com/yindf/taskfold) - Wraps work in named tasks and folds each finished task's whole span of messages into one summary at the next step boundary, with the original messages restorable on demand.
 - [yuezengwu/dsh-explain](https://github.com/yuezengwu/dsh-explain) - Local-first learning mode: cross-session learning threads with per-source explanations.
 
 ### Memory

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ DeepSeek Harness 是 DeepSeek 开源的 agent harness——既是可直接运行
 - [weibaohui/dsh-continue](https://github.com/weibaohui/dsh-continue) — 自动续跑：agent 会话中断后自动续上，规则表按失败类型（限流/额度/鉴权/上下文超限/崩溃孤儿）路由——退避重试、换模型、压缩上下文后继续或止损通知，规则可视化编辑，全程活动日志。
 - [weibaohui/dsh-smart-title](https://github.com/weibaohui/dsh-smart-title) — 会话智能标题：每轮对话结束后用一次独立的辅助 LLM 调用对「用户消息+助手回答」的完整转写做总结，标题跟随会话真实主题而不是复述第一句话；首条消息即时生成标题、内置标题失败在后续轮次自动重试、用户手动改名绝不被覆盖、自动跳过子代理与 fork 会话。
 - [Wine-Red/dsh-prompt-stash](https://github.com/Wine-Red/dsh-prompt-stash) — 本地、按会话隔离的 LIFO 输入暂存：临时收起未完成的输入，之后安全恢复并继续编辑。
+- [yindf/taskfold](https://github.com/yindf/taskfold) — 用命名任务包住工作过程；任务结束后在下一个步骤边界把整段消息折叠成一段摘要，原文可随时还原。
 - [yuezengwu/dsh-explain](https://github.com/yuezengwu/dsh-explain) — 本地优先学习模式：跨会话全局学习线程、按来源讲解。
 
 ### 🧠 记忆


### PR DESCRIPTION
Adds [yindf/taskfold](https://github.com/yindf/taskfold) to **Sessions & Messages** in both `README.en.md` and `README.md`, inserted in alphabetical order (before `yuezengwu/dsh-explain`).

It wraps work in named tasks (`task_begin` / `task_end`). When a task closes, its whole span of messages is folded into one titled summary at the next step boundary, and `fold_recall({ fold: N })` regenerates the original messages from an on-disk archive at any time.

- `package.json` declares `dsh.bundle.patch: ./cordis.patch.yml` at the repo root.
- Real, working code: 9 offline test files, `npm test` green.
- Repo created 2026-09-02, not archived, `dsh-plugin` topic present.
- Prebuilt tarball attached to the v0.31.1 GitHub Release.